### PR TITLE
fix: resolve host IP dynamically for sandbox MCP connectivity

### DIFF
--- a/crates/bot/src/lib.rs
+++ b/crates/bot/src/lib.rs
@@ -302,12 +302,6 @@ async fn run_async(args: BotArgs) -> miette::Result<bool> {
         let mut grpc_client = rightclaw::openshell::connect_grpc(&mtls_dir).await?;
         let sandbox_exists = rightclaw::openshell::is_sandbox_ready(&mut grpc_client, &sandbox).await?;
 
-        if sandbox_exists {
-            // Reuse existing sandbox — just apply updated policy.
-            tracing::info!(agent = %args.agent, "reusing existing sandbox");
-            rightclaw::openshell::apply_policy(&sandbox, &policy_path).await?;
-        }
-
         if !sandbox_exists {
             return Err(miette::miette!(
                 help = format!("Run `rightclaw init` or `rightclaw agent init {}` to create the sandbox", args.agent),
@@ -315,6 +309,22 @@ async fn run_async(args: BotArgs) -> miette::Result<bool> {
                 sandbox
             ));
         }
+
+        // Resolve host IP from inside sandbox for policy allowed_ips.
+        let sandbox_id = rightclaw::openshell::resolve_sandbox_id(&mut grpc_client, &sandbox).await?;
+        let host_ip = rightclaw::openshell::resolve_host_ip(&mut grpc_client, &sandbox_id).await?;
+
+        // Regenerate policy with resolved host IP and apply.
+        let network_policy = config.network_policy.clone();
+        let policy_content = rightclaw::codegen::policy::generate_policy(
+            rightclaw::runtime::MCP_HTTP_PORT,
+            &network_policy,
+            host_ip,
+        );
+        std::fs::write(&policy_path, &policy_content)
+            .map_err(|e| miette::miette!("failed to write policy.yaml: {e:#}"))?;
+        tracing::info!(agent = %args.agent, "reusing existing sandbox, applying policy with host_ip={:?}", host_ip);
+        rightclaw::openshell::apply_policy(&sandbox, &policy_path).await?;
 
         // Generate SSH config.
         let ssh_config_dir = home.join("run").join("ssh");

--- a/crates/rightclaw-cli/tests/cli_integration.rs
+++ b/crates/rightclaw-cli/tests/cli_integration.rs
@@ -486,6 +486,7 @@ fn test_policy_validates_against_openshell() {
         rightclaw::codegen::policy::generate_policy(
             rightclaw::runtime::MCP_HTTP_PORT,
             &rightclaw::agent::types::NetworkPolicy::Permissive,
+            None,
         );
     let tmpfile = tempdir().unwrap();
     let policy_path = tmpfile.path().join("test-policy.yaml");

--- a/crates/rightclaw/src/codegen/pipeline.rs
+++ b/crates/rightclaw/src/codegen/pipeline.rs
@@ -236,7 +236,7 @@ pub fn run_single_agent_codegen(
         .map(|c| c.network_policy.clone())
         .unwrap_or_default();
     let mcp_port = crate::runtime::MCP_HTTP_PORT;
-    let policy_content = crate::codegen::policy::generate_policy(mcp_port, &network_policy);
+    let policy_content = crate::codegen::policy::generate_policy(mcp_port, &network_policy, None);
     std::fs::write(agent.path.join("policy.yaml"), &policy_content).map_err(|e| {
         miette::miette!(
             "failed to write policy.yaml for '{}': {e:#}",

--- a/crates/rightclaw/src/codegen/policy.rs
+++ b/crates/rightclaw/src/codegen/policy.rs
@@ -32,11 +32,18 @@ fn restrictive_endpoints() -> String {
 ///
 /// `right_mcp_port`: TCP port for the host-side right MCP HTTP server.
 /// `network_policy`: Controls which outbound HTTPS domains are allowed.
+/// `host_ip`: Resolved IP of `host.docker.internal` from inside the sandbox.
+///   When `Some`, uses the exact IP/32 in `allowed_ips`. When `None`, falls back
+///   to common Docker network ranges (172.16.0.0/12 + 192.168.0.0/16).
 ///
 /// Network policy allows outbound HTTPS (port 443) with TLS termination
 /// so the OpenShell proxy can inspect traffic. The right MCP server on the host
 /// is accessed via plain HTTP through the Docker bridge network.
-pub fn generate_policy(right_mcp_port: u16, network_policy: &NetworkPolicy) -> String {
+pub fn generate_policy(
+    right_mcp_port: u16,
+    network_policy: &NetworkPolicy,
+    host_ip: Option<std::net::IpAddr>,
+) -> String {
     let network_section = match network_policy {
         NetworkPolicy::Permissive => r#"  outbound:
     endpoints:
@@ -58,6 +65,11 @@ pub fn generate_policy(right_mcp_port: u16, network_policy: &NetworkPolicy) -> S
                 restrictive_endpoints()
             )
         }
+    };
+
+    let allowed_ips = match host_ip {
+        Some(ip) => format!("          - \"{ip}/32\""),
+        None => "          - \"172.16.0.0/12\"\n          - \"192.168.0.0/16\"".to_owned(),
     };
 
     format!(
@@ -92,7 +104,7 @@ network_policies:
       - host: "host.docker.internal"
         port: {right_mcp_port}
         allowed_ips:
-          - "172.16.0.0/12"
+{allowed_ips}
         protocol: rest
         access: full
     binaries:
@@ -107,7 +119,7 @@ mod tests {
 
     #[test]
     fn generates_policy_with_right_mcp_port() {
-        let policy = generate_policy(8100, &NetworkPolicy::Permissive);
+        let policy = generate_policy(8100, &NetworkPolicy::Permissive, None);
         assert!(policy.contains("host.docker.internal"));
         assert!(policy.contains("8100"));
         assert!(policy.contains("172.16.0.0/12"));
@@ -118,7 +130,7 @@ mod tests {
 
     #[test]
     fn allows_all_outbound_https_and_http() {
-        let policy = generate_policy(8100, &NetworkPolicy::Permissive);
+        let policy = generate_policy(8100, &NetworkPolicy::Permissive, None);
         assert!(policy.contains(r#"host: "**.*""#));
         assert!(policy.contains("port: 443"));
         assert!(policy.contains("port: 80"));
@@ -128,7 +140,7 @@ mod tests {
 
     #[test]
     fn right_mcp_port_configurable() {
-        let policy = generate_policy(9000, &NetworkPolicy::Permissive);
+        let policy = generate_policy(9000, &NetworkPolicy::Permissive, None);
         assert!(policy.contains("9000"));
         assert!(!policy.contains("8100"));
     }
@@ -136,7 +148,7 @@ mod tests {
     /// OpenShell rejects bare `*` host wildcards — must use `*.example.com` or `*.*` patterns.
     #[test]
     fn no_bare_star_host_wildcards() {
-        let policy = generate_policy(8100, &NetworkPolicy::Permissive);
+        let policy = generate_policy(8100, &NetworkPolicy::Permissive, None);
         for line in policy.lines() {
             let trimmed = line.trim();
             if trimmed.starts_with("host:") {
@@ -152,7 +164,7 @@ mod tests {
     /// Policy YAML must be valid YAML and contain required OpenShell sections.
     #[test]
     fn policy_is_valid_yaml_with_required_sections() {
-        let policy = generate_policy(8100, &NetworkPolicy::Permissive);
+        let policy = generate_policy(8100, &NetworkPolicy::Permissive, None);
         let parsed: serde_json::Value = serde_saphyr::from_str(&policy)
             .expect("policy must be valid YAML");
         let obj = parsed.as_object().expect("policy root must be a mapping");
@@ -164,7 +176,7 @@ mod tests {
 
     #[test]
     fn restrictive_policy_allows_only_anthropic_domains() {
-        let policy = generate_policy(8100, &NetworkPolicy::Restrictive);
+        let policy = generate_policy(8100, &NetworkPolicy::Restrictive, None);
         assert!(policy.contains(r#"host: "*.anthropic.com""#));
         assert!(policy.contains(r#"host: "anthropic.com""#));
         assert!(policy.contains(r#"host: "*.claude.com""#));
@@ -176,14 +188,14 @@ mod tests {
 
     #[test]
     fn permissive_policy_allows_all_https() {
-        let policy = generate_policy(8100, &NetworkPolicy::Permissive);
+        let policy = generate_policy(8100, &NetworkPolicy::Permissive, None);
         assert!(policy.contains(r#"host: "**.*""#));
         assert!(!policy.contains(r#"host: "*.anthropic.com""#), "permissive uses wildcard, not explicit domains");
     }
 
     #[test]
     fn restrictive_policy_is_valid_yaml() {
-        let policy = generate_policy(8100, &NetworkPolicy::Restrictive);
+        let policy = generate_policy(8100, &NetworkPolicy::Restrictive, None);
         let parsed: serde_json::Value = serde_saphyr::from_str(&policy)
             .expect("restrictive policy must be valid YAML");
         let obj = parsed.as_object().expect("policy root must be a mapping");
@@ -192,7 +204,7 @@ mod tests {
 
     #[test]
     fn restrictive_policy_has_no_bare_star_wildcards() {
-        let policy = generate_policy(8100, &NetworkPolicy::Restrictive);
+        let policy = generate_policy(8100, &NetworkPolicy::Restrictive, None);
         for line in policy.lines() {
             let trimmed = line.trim();
             if trimmed.starts_with("host:") {
@@ -203,5 +215,28 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn host_ip_none_uses_fallback_ranges() {
+        let policy = generate_policy(8100, &NetworkPolicy::Permissive, None);
+        assert!(policy.contains("172.16.0.0/12"), "must include Docker bridge range");
+        assert!(policy.contains("192.168.0.0/16"), "must include Docker Desktop range");
+    }
+
+    #[test]
+    fn host_ip_some_uses_exact_ip() {
+        let ip: std::net::IpAddr = "192.168.65.254".parse().unwrap();
+        let policy = generate_policy(8100, &NetworkPolicy::Permissive, Some(ip));
+        assert!(policy.contains("192.168.65.254/32"), "must use exact IP/32");
+        assert!(!policy.contains("172.16.0.0/12"), "must not include fallback range");
+    }
+
+    #[test]
+    fn host_ip_some_produces_valid_yaml() {
+        let ip: std::net::IpAddr = "10.0.0.1".parse().unwrap();
+        let policy = generate_policy(8100, &NetworkPolicy::Permissive, Some(ip));
+        let _parsed: serde_json::Value = serde_saphyr::from_str(&policy)
+            .expect("policy with dynamic IP must be valid YAML");
     }
 }

--- a/crates/rightclaw/src/init.rs
+++ b/crates/rightclaw/src/init.rs
@@ -144,6 +144,7 @@ pub fn init_agent(
         let policy_yaml = crate::codegen::policy::generate_policy(
             crate::runtime::MCP_HTTP_PORT,
             &ov.network_policy,
+            None,
         );
         std::fs::write(agents_dir.join("policy.yaml"), &policy_yaml)
             .map_err(|e| miette::miette!("Failed to write policy.yaml: {e}"))?;

--- a/crates/rightclaw/src/openshell.rs
+++ b/crates/rightclaw/src/openshell.rs
@@ -759,6 +759,50 @@ async fn wait_for_ssh(
     }
 }
 
+/// Resolve the host IP as seen from inside a sandbox.
+///
+/// Runs `getent ahostsv4 host.docker.internal` inside the sandbox via gRPC exec
+/// and parses the first IPv4 address from the output.
+///
+/// This IP varies by platform:
+/// - macOS Docker Desktop: `192.168.65.254`
+/// - Linux Docker bridge: `172.17.0.1`
+/// - Custom networks: varies
+///
+/// Returns `None` if `host.docker.internal` doesn't resolve (e.g. Linux without
+/// `--add-host` flag), or if the sandbox exec fails.
+pub async fn resolve_host_ip(
+    client: &mut OpenShellClient<Channel>,
+    sandbox_id: &str,
+) -> miette::Result<Option<std::net::IpAddr>> {
+    let (stdout, exit_code) = exec_in_sandbox(
+        client,
+        sandbox_id,
+        &["getent", "ahostsv4", "host.docker.internal"],
+    )
+    .await?;
+
+    if exit_code != 0 || stdout.trim().is_empty() {
+        tracing::warn!(sandbox_id, exit_code, "host.docker.internal not resolvable in sandbox");
+        return Ok(None);
+    }
+
+    // Output format: "192.168.65.254  STREAM host.docker.internal\n192.168.65.254  DGRAM\n..."
+    // Take the first token of the first line.
+    let ip_str = stdout
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().next())
+        .ok_or_else(|| miette::miette!("unexpected getent output: {stdout}"))?;
+
+    let ip: std::net::IpAddr = ip_str
+        .parse()
+        .map_err(|e| miette::miette!("failed to parse host IP '{ip_str}': {e}"))?;
+
+    tracing::info!(sandbox_id, %ip, "resolved host.docker.internal");
+    Ok(Some(ip))
+}
+
 /// Verify that critical files exist in the sandbox after creation/upload.
 ///
 /// Uses gRPC `ExecSandbox` to check file existence (fast, no download).

--- a/crates/rightclaw/src/openshell_tests.rs
+++ b/crates/rightclaw/src/openshell_tests.rs
@@ -400,7 +400,7 @@ async fn exec_immediately_after_sandbox_create_reproduces_init_flow() {
     // SSH transport take significantly longer to become ready.
     let tmp = tempfile::tempdir().unwrap();
     let policy_path = tmp.path().join("policy.yaml");
-    let policy = crate::codegen::policy::generate_policy(18927, &crate::agent::types::NetworkPolicy::Restrictive);
+    let policy = crate::codegen::policy::generate_policy(18927, &crate::agent::types::NetworkPolicy::Restrictive, None);
     std::fs::write(&policy_path, &policy).unwrap();
 
     // Create a staging dir with a small test file (same as init uploads agent defs).


### PR DESCRIPTION
## Summary

- The `right` MCP server was unreachable from OpenShell sandboxes on macOS because `host.docker.internal` resolves to `192.168.65.254` (Docker Desktop VM), outside the hardcoded `allowed_ips: 172.16.0.0/12`
- Added `resolve_host_ip()` in `openshell.rs` — runs `getent ahostsv4 host.docker.internal` inside the sandbox via gRPC exec to get the actual IP
- Bot startup now resolves host IP, regenerates `policy.yaml` with exact IP/32, then applies it
- Falls back to broad ranges (`172.16.0.0/12` + `192.168.0.0/16`) when resolution fails (e.g. Linux without `host.docker.internal`)

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` — core + bot tests pass (CLI integration failures are pre-existing sandbox conflicts)
- [x] Verified MCP connectivity from sandbox after policy fix (`curl` to `host.docker.internal:8100` returns tool list)
- [x] Verified Claude Code inside sandbox connects to `right` MCP and uses `mcp_add` tool correctly