### PR TITLE
docs(readme): add toc, hero bullets, collapse topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ and getting even that far costs a weekend: a chat backend, a memory store, a tun
 
 right agent fixes both. the pieces are picked, the wiring is done, telegram is your only console.
 
-<p align="center"><img src="assets/section-divider.svg" width="80" height="2" alt=""></p>
-
 <img src="assets/section-mark.svg" height="20" alt="">
 
 ## what we picked for you
@@ -56,8 +54,6 @@ we make the choices for you and polish what we ship. the box is closed:
 - **sandbox.** [nvidia openshell](https://github.com/NVIDIA/OpenShell), on by default. the only opt-out is for agents that need host access (e.g. computer-use, browser automation), and that's set explicitly per-agent.
 
 the consequence: features arrive slowly. we polish what's here before adding what's next. if a knob isn't exposed, we haven't found a way to add it without making the product worse for everyone already using it.
-
-<p align="center"><img src="assets/section-divider.svg" width="80" height="2" alt=""></p>
 
 <img src="assets/section-mark.svg" height="20" alt="">
 
@@ -77,8 +73,6 @@ right up
 ```
 
 full install guide: [docs/INSTALL.md](docs/INSTALL.md).
-
-<p align="center"><img src="assets/section-divider.svg" width="80" height="2" alt=""></p>
 
 <img src="assets/section-mark.svg" height="20" alt="">
 
@@ -103,8 +97,6 @@ the first session with a fresh agent is a bootstrap, not a chat. the agent answe
 ### one place to run it from
 
 after `right up`, the terminal is done. claude login, mcp authorization, file attachments, cron notifications, `/doctor`, `/reset`. all in telegram.
-
-<p align="center"><img src="assets/section-divider.svg" width="80" height="2" alt=""></p>
 
 <img src="assets/section-mark.svg" height="20" alt="">
 
@@ -208,8 +200,6 @@ outbound traffic from the sandbox goes through openshell's policy engine. tls is
 
 the default policy is permissive. one line in `agent.yaml` switches to restrictive: anthropic and claude endpoints only.
 
-<p align="center"><img src="assets/section-divider.svg" width="80" height="2" alt=""></p>
-
 <img src="assets/section-mark.svg" height="20" alt="">
 
 ## how it compares
@@ -226,8 +216,6 @@ the default policy is permissive. one line in `agent.yaml` switches to restricti
 | scope | configurable everything | one opinionated path |
 
 other runtimes ship breadth and leave the wiring to you. right agent ships one path and does the wiring itself.
-
-<p align="center"><img src="assets/section-divider.svg" width="80" height="2" alt=""></p>
 
 <img src="assets/section-mark.svg" height="20" alt="">
 
@@ -254,8 +242,6 @@ next:
 
 full tracker on [github issues](https://github.com/onsails/right-agent/issues).
 
-<p align="center"><img src="assets/section-divider.svg" width="80" height="2" alt=""></p>
-
 <img src="assets/section-mark.svg" height="20" alt="">
 
 ## docs
@@ -265,15 +251,11 @@ full tracker on [github issues](https://github.com/onsails/right-agent/issues).
 - [architecture](ARCHITECTURE.md) — internal topology, sqlite schema, invocation contract
 - [prompting system](PROMPT_SYSTEM.md) — how agent system prompts are assembled
 
-<p align="center"><img src="assets/section-divider.svg" width="80" height="2" alt=""></p>
-
 <img src="assets/section-mark.svg" height="20" alt="">
 
 ## license
 
 apache-2.0.
-
-<p align="center"><img src="assets/section-divider.svg" width="80" height="2" alt=""></p>
 
 <img src="assets/section-mark.svg" height="20" alt="">
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@
   <a href="#roadmap">roadmap</a>
 </p>
 
-## the problem
+## <img src="assets/section-mark.svg" height="20" alt=""> the problem
 
-<img src="assets/section-mark.svg" align="left" height="20" alt=""> in most agent setups, the agent you leave running long-term has two problems baked in.
+in most agent setups, the agent you leave running long-term has two problems baked in.
 
 tokens sit in a plaintext config file. the sandbox is missing or fake. context resets on restart. enough for a demo, not for what you depend on.
 
@@ -37,9 +37,9 @@ and getting even that far costs a weekend: a chat backend, a memory store, a tun
 
 right agent fixes both. the pieces are picked, the wiring is done, telegram is your only console.
 
-## what we picked for you
+## <img src="assets/section-mark.svg" height="20" alt=""> what we picked for you
 
-<img src="assets/section-mark.svg" align="left" height="20" alt=""> every agent inside its own sandbox. security first; usability never sacrificed for it. nothing else gets a vote.
+every agent inside its own sandbox. security first; usability never sacrificed for it. nothing else gets a vote.
 
 we make the choices for you and polish what we ship. the box is closed:
 
@@ -51,9 +51,9 @@ we make the choices for you and polish what we ship. the box is closed:
 
 the consequence: features arrive slowly. we polish what's here before adding what's next. if a knob isn't exposed, we haven't found a way to add it without making the product worse for everyone already using it.
 
-## quick start
+## <img src="assets/section-mark.svg" height="20" alt=""> quick start
 
-<img src="assets/section-mark.svg" align="left" height="20" alt=""> prerequisites:
+prerequisites:
 
 - [claude code cli](https://docs.anthropic.com/en/docs/claude-code)
 - telegram bot token from [@BotFather](https://t.me/BotFather)
@@ -68,9 +68,7 @@ right up
 
 full install guide: [docs/INSTALL.md](docs/INSTALL.md).
 
-## what you get
-
-<img src="assets/section-mark.svg" height="20" alt="">
+## <img src="assets/section-mark.svg" height="20" alt=""> what you get
 
 ### multiple agents on one subscription
 
@@ -92,9 +90,9 @@ the first session with a fresh agent is a bootstrap, not a chat. the agent answe
 
 after `right up`, the terminal is done. claude login, mcp authorization, file attachments, cron notifications, `/doctor`, `/reset`. all in telegram.
 
-## how it stays safe
+## <img src="assets/section-mark.svg" height="20" alt=""> how it stays safe
 
-<img src="assets/section-mark.svg" align="left" height="20" alt=""> an agent you leave running long-term will eventually fetch a poisoned webpage, install a hostile skill, or accept a malicious memory through an mcp tool. the design assumes this. what matters is what the agent can reach when it does.
+an agent you leave running long-term will eventually fetch a poisoned webpage, install a hostile skill, or accept a malicious memory through an mcp tool. the design assumes this. what matters is what the agent can reach when it does.
 
 on a typical agent setup, the agent has direct access to:
 
@@ -192,9 +190,7 @@ outbound traffic from the sandbox goes through openshell's policy engine. tls is
 
 the default policy is permissive. one line in `agent.yaml` switches to restrictive: anthropic and claude endpoints only.
 
-## how it compares
-
-<img src="assets/section-mark.svg" height="20" alt="">
+## <img src="assets/section-mark.svg" height="20" alt=""> how it compares
 
 | | typical multi-agent runtime | right agent |
 |---|---|---|
@@ -209,9 +205,9 @@ the default policy is permissive. one line in `agent.yaml` switches to restricti
 
 other runtimes ship breadth and leave the wiring to you. right agent ships one path and does the wiring itself.
 
-## roadmap
+## <img src="assets/section-mark.svg" height="20" alt=""> roadmap
 
-<img src="assets/section-mark.svg" align="left" height="20" alt=""> shipped:
+shipped:
 - multi-agent orchestration, sandboxed by default
 - mcp aggregator with auto-detected oauth, bearer, header, query-string auth
 - evolving identity: agent writes its own `IDENTITY.md` / `SOUL.md` / `USER.md`
@@ -232,19 +228,17 @@ next:
 
 full tracker on [github issues](https://github.com/onsails/right-agent/issues).
 
-## docs
-
-<img src="assets/section-mark.svg" height="20" alt="">
+## <img src="assets/section-mark.svg" height="20" alt=""> docs
 
 - [installation](docs/INSTALL.md) — full prerequisites
 - [security model](docs/SECURITY.md) — policies, credential isolation, threat model
 - [architecture](ARCHITECTURE.md) — internal topology, sqlite schema, invocation contract
 - [prompting system](PROMPT_SYSTEM.md) — how agent system prompts are assembled
 
-## license
+## <img src="assets/section-mark.svg" height="20" alt=""> license
 
-<img src="assets/section-mark.svg" align="left" height="20" alt=""> apache-2.0.
+apache-2.0.
 
-## credits
+## <img src="assets/section-mark.svg" height="20" alt=""> credits
 
-<img src="assets/section-mark.svg" align="left" height="20" alt=""> built on [claude code](https://docs.anthropic.com/en/docs/claude-code), [nvidia openshell](https://github.com/NVIDIA/OpenShell), and [process-compose](https://github.com/F1bonacc1/process-compose).
+built on [claude code](https://docs.anthropic.com/en/docs/claude-code), [nvidia openshell](https://github.com/NVIDIA/OpenShell), and [process-compose](https://github.com/F1bonacc1/process-compose).

--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@
 
 ## the problem
 
-<img src="assets/section-mark.svg" height="20" alt="">
-
-in most agent setups, the agent you leave running long-term has two problems baked in.
+<img src="assets/section-mark.svg" align="left" height="20" alt=""> in most agent setups, the agent you leave running long-term has two problems baked in.
 
 tokens sit in a plaintext config file. the sandbox is missing or fake. context resets on restart. enough for a demo, not for what you depend on.
 
@@ -41,9 +39,7 @@ right agent fixes both. the pieces are picked, the wiring is done, telegram is y
 
 ## what we picked for you
 
-<img src="assets/section-mark.svg" height="20" alt="">
-
-every agent inside its own sandbox. security first; usability never sacrificed for it. nothing else gets a vote.
+<img src="assets/section-mark.svg" align="left" height="20" alt=""> every agent inside its own sandbox. security first; usability never sacrificed for it. nothing else gets a vote.
 
 we make the choices for you and polish what we ship. the box is closed:
 
@@ -57,9 +53,7 @@ the consequence: features arrive slowly. we polish what's here before adding wha
 
 ## quick start
 
-<img src="assets/section-mark.svg" height="20" alt="">
-
-prerequisites:
+<img src="assets/section-mark.svg" align="left" height="20" alt=""> prerequisites:
 
 - [claude code cli](https://docs.anthropic.com/en/docs/claude-code)
 - telegram bot token from [@BotFather](https://t.me/BotFather)
@@ -100,9 +94,7 @@ after `right up`, the terminal is done. claude login, mcp authorization, file at
 
 ## how it stays safe
 
-<img src="assets/section-mark.svg" height="20" alt="">
-
-an agent you leave running long-term will eventually fetch a poisoned webpage, install a hostile skill, or accept a malicious memory through an mcp tool. the design assumes this. what matters is what the agent can reach when it does.
+<img src="assets/section-mark.svg" align="left" height="20" alt=""> an agent you leave running long-term will eventually fetch a poisoned webpage, install a hostile skill, or accept a malicious memory through an mcp tool. the design assumes this. what matters is what the agent can reach when it does.
 
 on a typical agent setup, the agent has direct access to:
 
@@ -219,9 +211,7 @@ other runtimes ship breadth and leave the wiring to you. right agent ships one p
 
 ## roadmap
 
-<img src="assets/section-mark.svg" height="20" alt="">
-
-shipped:
+<img src="assets/section-mark.svg" align="left" height="20" alt=""> shipped:
 - multi-agent orchestration, sandboxed by default
 - mcp aggregator with auto-detected oauth, bearer, header, query-string auth
 - evolving identity: agent writes its own `IDENTITY.md` / `SOUL.md` / `USER.md`
@@ -253,12 +243,8 @@ full tracker on [github issues](https://github.com/onsails/right-agent/issues).
 
 ## license
 
-<img src="assets/section-mark.svg" height="20" alt="">
-
-apache-2.0.
+<img src="assets/section-mark.svg" align="left" height="20" alt=""> apache-2.0.
 
 ## credits
 
-<img src="assets/section-mark.svg" height="20" alt="">
-
-built on [claude code](https://docs.anthropic.com/en/docs/claude-code), [nvidia openshell](https://github.com/NVIDIA/OpenShell), and [process-compose](https://github.com/F1bonacc1/process-compose).
+<img src="assets/section-mark.svg" align="left" height="20" alt=""> built on [claude code](https://docs.anthropic.com/en/docs/claude-code), [nvidia openshell](https://github.com/NVIDIA/OpenShell), and [process-compose](https://github.com/F1bonacc1/process-compose).

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ full install guide: [docs/INSTALL.md](docs/INSTALL.md).
 
 ## <img src="assets/section-mark.svg" height="20" alt=""> what you get
 
-### multiple agents on one subscription
+### <img src="assets/subsection-mark.svg" height="14" alt=""> multiple agents on one subscription
 
 each agent is a separate claude code session in its own sandbox: separate identity, separate memory, separate telegram thread. no per-agent api key. all of them run on your one claude subscription.
 
-### memory that survives restarts
+### <img src="assets/subsection-mark.svg" height="14" alt=""> memory that survives restarts
 
 two memory backends, picked at agent init.
 
@@ -82,11 +82,11 @@ two memory backends, picked at agent init.
 
 **`MEMORY.md`** is a local file the agent maintains itself. no cloud, no semantic recall, simpler.
 
-### identity that writes itself
+### <img src="assets/subsection-mark.svg" height="14" alt=""> identity that writes itself
 
 the first session with a fresh agent is a bootstrap, not a chat. the agent answers questions about who it wants to be (name, tone, boundaries, relationship with you) and writes `IDENTITY.md`, `SOUL.md`, `USER.md` itself. those files load into every system prompt afterwards. on restart, on model swap, on upgrade, the agent stays itself.
 
-### one place to run it from
+### <img src="assets/subsection-mark.svg" height="14" alt=""> one place to run it from
 
 after `right up`, the terminal is done. claude login, mcp authorization, file attachments, cron notifications, `/doctor`, `/reset`. all in telegram.
 
@@ -106,19 +106,19 @@ on a typical agent setup, the agent has direct access to:
 
 one compromised turn, the attacker walks out with all of it.
 
-### the sandbox boundary
+### <img src="assets/subsection-mark.svg" height="14" alt=""> the sandbox boundary
 
 every claude code session runs inside an [nvidia openshell](https://github.com/NVIDIA/OpenShell) sandbox. the agent reads and writes only inside its own workspace. nothing in `~/.ssh`, `~/.aws`, `~/.config/gcloud`, or your source tree is reachable. no other agent's files are reachable. no escape route.
 
 openshell is purpose-built for ai agents, not a container runtime stretched to fit. tls inspection, domain allowlists, and request logging are per-sandbox primitives.
 
-### credentials live outside the sandbox
+### <img src="assets/subsection-mark.svg" height="14" alt=""> credentials live outside the sandbox
 
 mcp tokens, oauth refresh tokens, and claude auth live on the host inside a single aggregator process. the sandbox sees a proxy endpoint, never the raw token. four auth patterns are detected and refreshed automatically: oauth, bearer, custom header, query string.
 
 worst case for a compromised agent: it misuses a tool while it's running. it cannot exfiltrate the credential.
 
-### the topology
+### <img src="assets/subsection-mark.svg" height="14" alt=""> the topology
 
 <details>
 <summary>show diagram</summary>
@@ -184,7 +184,7 @@ flowchart TB
 
 </details>
 
-### what egress looks like
+### <img src="assets/subsection-mark.svg" height="14" alt=""> what egress looks like
 
 outbound traffic from the sandbox goes through openshell's policy engine. tls is terminated per-request. the destination is matched against the domain allowlist, and the request is logged. nothing leaves silently.
 

--- a/README.md
+++ b/README.md
@@ -3,18 +3,28 @@
 </p>
 
 <p align="center">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="license"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-E8632A.svg" alt="license"></a>
   <a href="https://github.com/onsails/right-agent/actions"><img src="https://github.com/onsails/right-agent/actions/workflows/build.yml/badge.svg" alt="build"></a>
-  <a href="https://t.me/rightclaw"><img src="https://img.shields.io/badge/Telegram-chat-blue?logo=telegram" alt="telegram"></a>
+  <a href="https://t.me/rightclaw"><img src="https://img.shields.io/badge/Telegram-chat-E8632A?logo=telegram" alt="telegram"></a>
 </p>
 
 <p align="center">
   <b>the proper claude code runtime</b><br/>
-  sandboxed multi-agent runtime. lives in telegram. runs on your $20 claude subscription.
+  telegram-native · sandboxed by default · runs on your $20 claude subscription
 </p>
 
 <p align="center">
   <img src="images/screenshot.png" alt="Right Agent in Telegram" width="720"/>
+</p>
+
+<p align="center">
+  <a href="#the-problem">the problem</a> ·
+  <a href="#what-we-picked-for-you">what we picked for you</a> ·
+  <a href="#quick-start">quick start</a> ·
+  <a href="#what-you-get">what you get</a> ·
+  <a href="#how-it-stays-safe">how it stays safe</a> ·
+  <a href="#how-it-compares">how it compares</a> ·
+  <a href="#roadmap">roadmap</a>
 </p>
 
 ## the problem
@@ -110,6 +120,9 @@ worst case for a compromised agent: it misuses a tool while it's running. it can
 
 ### the topology
 
+<details>
+<summary>show diagram</summary>
+
 ```mermaid
 flowchart TB
   U[You]
@@ -168,6 +181,8 @@ flowchart TB
   style SANDBOX_1 stroke:#E8632A,stroke-width:2px
   style SANDBOX_2 stroke:#E8632A,stroke-width:2px
 ```
+
+</details>
 
 ### what egress looks like
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@
   <a href="#roadmap">roadmap</a>
 </p>
 
-<img src="assets/section-mark.svg" height="20" alt="">
-
 ## the problem
+
+<img src="assets/section-mark.svg" height="20" alt="">
 
 in most agent setups, the agent you leave running long-term has two problems baked in.
 
@@ -39,9 +39,9 @@ and getting even that far costs a weekend: a chat backend, a memory store, a tun
 
 right agent fixes both. the pieces are picked, the wiring is done, telegram is your only console.
 
-<img src="assets/section-mark.svg" height="20" alt="">
-
 ## what we picked for you
+
+<img src="assets/section-mark.svg" height="20" alt="">
 
 every agent inside its own sandbox. security first; usability never sacrificed for it. nothing else gets a vote.
 
@@ -55,9 +55,9 @@ we make the choices for you and polish what we ship. the box is closed:
 
 the consequence: features arrive slowly. we polish what's here before adding what's next. if a knob isn't exposed, we haven't found a way to add it without making the product worse for everyone already using it.
 
-<img src="assets/section-mark.svg" height="20" alt="">
-
 ## quick start
+
+<img src="assets/section-mark.svg" height="20" alt="">
 
 prerequisites:
 
@@ -74,9 +74,9 @@ right up
 
 full install guide: [docs/INSTALL.md](docs/INSTALL.md).
 
-<img src="assets/section-mark.svg" height="20" alt="">
-
 ## what you get
+
+<img src="assets/section-mark.svg" height="20" alt="">
 
 ### multiple agents on one subscription
 
@@ -98,9 +98,9 @@ the first session with a fresh agent is a bootstrap, not a chat. the agent answe
 
 after `right up`, the terminal is done. claude login, mcp authorization, file attachments, cron notifications, `/doctor`, `/reset`. all in telegram.
 
-<img src="assets/section-mark.svg" height="20" alt="">
-
 ## how it stays safe
+
+<img src="assets/section-mark.svg" height="20" alt="">
 
 an agent you leave running long-term will eventually fetch a poisoned webpage, install a hostile skill, or accept a malicious memory through an mcp tool. the design assumes this. what matters is what the agent can reach when it does.
 
@@ -200,9 +200,9 @@ outbound traffic from the sandbox goes through openshell's policy engine. tls is
 
 the default policy is permissive. one line in `agent.yaml` switches to restrictive: anthropic and claude endpoints only.
 
-<img src="assets/section-mark.svg" height="20" alt="">
-
 ## how it compares
+
+<img src="assets/section-mark.svg" height="20" alt="">
 
 | | typical multi-agent runtime | right agent |
 |---|---|---|
@@ -217,9 +217,9 @@ the default policy is permissive. one line in `agent.yaml` switches to restricti
 
 other runtimes ship breadth and leave the wiring to you. right agent ships one path and does the wiring itself.
 
-<img src="assets/section-mark.svg" height="20" alt="">
-
 ## roadmap
+
+<img src="assets/section-mark.svg" height="20" alt="">
 
 shipped:
 - multi-agent orchestration, sandboxed by default
@@ -242,23 +242,23 @@ next:
 
 full tracker on [github issues](https://github.com/onsails/right-agent/issues).
 
-<img src="assets/section-mark.svg" height="20" alt="">
-
 ## docs
+
+<img src="assets/section-mark.svg" height="20" alt="">
 
 - [installation](docs/INSTALL.md) — full prerequisites
 - [security model](docs/SECURITY.md) — policies, credential isolation, threat model
 - [architecture](ARCHITECTURE.md) — internal topology, sqlite schema, invocation contract
 - [prompting system](PROMPT_SYSTEM.md) — how agent system prompts are assembled
 
-<img src="assets/section-mark.svg" height="20" alt="">
-
 ## license
+
+<img src="assets/section-mark.svg" height="20" alt="">
 
 apache-2.0.
 
-<img src="assets/section-mark.svg" height="20" alt="">
-
 ## credits
+
+<img src="assets/section-mark.svg" height="20" alt="">
 
 built on [claude code](https://docs.anthropic.com/en/docs/claude-code), [nvidia openshell](https://github.com/NVIDIA/OpenShell), and [process-compose](https://github.com/F1bonacc1/process-compose).

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@
   <a href="#roadmap">roadmap</a>
 </p>
 
+<img src="assets/section-mark.svg" height="20" alt="">
+
 ## the problem
 
 in most agent setups, the agent you leave running long-term has two problems baked in.
@@ -36,6 +38,10 @@ tokens sit in a plaintext config file. the sandbox is missing or fake. context r
 and getting even that far costs a weekend: a chat backend, a memory store, a tunnel, a sandbox layer — pick them, wire them. the agent works on monday. it didn't have to take a weekend.
 
 right agent fixes both. the pieces are picked, the wiring is done, telegram is your only console.
+
+<p align="center"><img src="assets/section-divider.svg" width="80" height="2" alt=""></p>
+
+<img src="assets/section-mark.svg" height="20" alt="">
 
 ## what we picked for you
 
@@ -50,6 +56,10 @@ we make the choices for you and polish what we ship. the box is closed:
 - **sandbox.** [nvidia openshell](https://github.com/NVIDIA/OpenShell), on by default. the only opt-out is for agents that need host access (e.g. computer-use, browser automation), and that's set explicitly per-agent.
 
 the consequence: features arrive slowly. we polish what's here before adding what's next. if a knob isn't exposed, we haven't found a way to add it without making the product worse for everyone already using it.
+
+<p align="center"><img src="assets/section-divider.svg" width="80" height="2" alt=""></p>
+
+<img src="assets/section-mark.svg" height="20" alt="">
 
 ## quick start
 
@@ -67,6 +77,10 @@ right up
 ```
 
 full install guide: [docs/INSTALL.md](docs/INSTALL.md).
+
+<p align="center"><img src="assets/section-divider.svg" width="80" height="2" alt=""></p>
+
+<img src="assets/section-mark.svg" height="20" alt="">
 
 ## what you get
 
@@ -89,6 +103,10 @@ the first session with a fresh agent is a bootstrap, not a chat. the agent answe
 ### one place to run it from
 
 after `right up`, the terminal is done. claude login, mcp authorization, file attachments, cron notifications, `/doctor`, `/reset`. all in telegram.
+
+<p align="center"><img src="assets/section-divider.svg" width="80" height="2" alt=""></p>
+
+<img src="assets/section-mark.svg" height="20" alt="">
 
 ## how it stays safe
 
@@ -190,6 +208,10 @@ outbound traffic from the sandbox goes through openshell's policy engine. tls is
 
 the default policy is permissive. one line in `agent.yaml` switches to restrictive: anthropic and claude endpoints only.
 
+<p align="center"><img src="assets/section-divider.svg" width="80" height="2" alt=""></p>
+
+<img src="assets/section-mark.svg" height="20" alt="">
+
 ## how it compares
 
 | | typical multi-agent runtime | right agent |
@@ -204,6 +226,10 @@ the default policy is permissive. one line in `agent.yaml` switches to restricti
 | scope | configurable everything | one opinionated path |
 
 other runtimes ship breadth and leave the wiring to you. right agent ships one path and does the wiring itself.
+
+<p align="center"><img src="assets/section-divider.svg" width="80" height="2" alt=""></p>
+
+<img src="assets/section-mark.svg" height="20" alt="">
 
 ## roadmap
 
@@ -228,6 +254,10 @@ next:
 
 full tracker on [github issues](https://github.com/onsails/right-agent/issues).
 
+<p align="center"><img src="assets/section-divider.svg" width="80" height="2" alt=""></p>
+
+<img src="assets/section-mark.svg" height="20" alt="">
+
 ## docs
 
 - [installation](docs/INSTALL.md) — full prerequisites
@@ -235,9 +265,17 @@ full tracker on [github issues](https://github.com/onsails/right-agent/issues).
 - [architecture](ARCHITECTURE.md) — internal topology, sqlite schema, invocation contract
 - [prompting system](PROMPT_SYSTEM.md) — how agent system prompts are assembled
 
+<p align="center"><img src="assets/section-divider.svg" width="80" height="2" alt=""></p>
+
+<img src="assets/section-mark.svg" height="20" alt="">
+
 ## license
 
 apache-2.0.
+
+<p align="center"><img src="assets/section-divider.svg" width="80" height="2" alt=""></p>
+
+<img src="assets/section-mark.svg" height="20" alt="">
 
 ## credits
 

--- a/assets/section-divider.svg
+++ b/assets/section-divider.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="80" height="2" viewBox="0 0 80 2" role="img" aria-label="">
-  <rect width="80" height="2" fill="#E8632A"/>
-</svg>

--- a/assets/section-divider.svg
+++ b/assets/section-divider.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="2" viewBox="0 0 80 2" role="img" aria-label="">
+  <rect width="80" height="2" fill="#E8632A"/>
+</svg>

--- a/assets/section-mark.svg
+++ b/assets/section-mark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="8" height="18" viewBox="0 0 8 18" role="img" aria-label="">
+  <rect width="8" height="18" fill="#E8632A"/>
+</svg>

--- a/assets/subsection-mark.svg
+++ b/assets/subsection-mark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="6" height="14" viewBox="0 0 6 14" role="img" aria-label="">
+  <rect width="6" height="14" fill="#666666"/>
+</svg>


### PR DESCRIPTION
## Summary

Three structural fixes to make the README scannable for a visitor who lands looking for the product, plus brand color presence in the hero. Currently 229 lines with no nav, dominated by a 94-line "## how it stays safe" (60 of which are an inline mermaid diagram).

- **Centered 3-claim subtitle under the tagline.** `telegram-native · sandboxed by default · runs on your $20 claude subscription`. Gives the fast skimmer the value prop without breaking the centered hero rhythm.
- **TOC pipe-row above "## the problem".** Centered, lowercase, links every H2. Reader who came for a specific section can jump.
- **License + Telegram badges in brand orange (`#E8632A`).** Build badge stays auto-colored — `brand-guidelines.html` §04.2 forbids orange for semantic states.
- **Topology mermaid collapsed in `<details>/<summary>`.** Diagram stays one click away; ~60 lines of source plus the rendered diagram no longer dominate the scroll. "## how it stays safe" visually shrinks.

Brand-voice-conformant: no emoji, no `[!NOTE]` callouts, no banners — just structural hierarchy + the brand color extended to non-semantic badges where the guidelines allow it.

## Test plan
- [ ] Render on github.com — verify the TOC links resolve to the right H2 anchors
- [ ] Verify the `<details>` collapses by default and the mermaid still renders inside when expanded
- [ ] Check the orange badges render correctly (text contrast OK on `#E8632A`)
- [ ] Visual check of the centered hero rhythm at typical viewport widths