### PR TITLE
chore: release v0.2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,114 +1,13 @@
 # Changelog
 ## [0.2.15] - 2026-05-18
 
-
-### Bug Fixes
-
-- **right-memory**: Handle ErrorKind::Quota in retain_queue::drain
-- **right-memory**: Exclude QuotaExhausted from CircuitOpen enqueue path
-- **deps-audit**: Consolidate test-crypto helper, document let-discard intent
-- **workspace**: Add debug: None to AgentConfig literal construction sites
-- Keep cron idle promise wording testable
-- Clarify learned skill receipt message
-- Clarify skill learning safeguards
-- **release-plz**: Add version requirement to internal path deps
-- **right-db**: Add chrono dev dependency for migration tests
-- **claude**: Accept up-to-date upgrade exit
-- **claude**: Accept current-version upgrade output
-- **bot**: Treat missing right mcp init as unhealthy
-- **bot**: Keep mcp init parser clippy-clean
-- **bot**: Narrow claude health lint allowances
-- **bot**: Bound claude health probe lifecycle
-- **bot**: Bound mcp repair operation
-- **bot**: Cancel mcp repair during dispatcher shutdown
-- **bot**: Correlate worker invocation logs
-- Align learned skills schema checks
-- Tighten learned skill reply signals
-- Validate learned skill event refs
-- **agent**: Align doctor memory schema version
-- Gate learned skill tools outside foreground
-- **restore**: Preserve implicit Hindsight bindings
-- **restore**: Fail binding validation before partial restore
-- **runtime**: Refresh tunnel after route changes
-- **restore**: Preserve sandbox agent recovery state
-- Ssh upgrade
-- **cli**: Quote agent ssh remote argv
-- **openshell**: Finish ssh remote argv quoting
-- **openshell**: Generate portable right mcp policy
-
-### Documentation
-
-- **right-memory**: Document QuotaExhausted stickiness in refresh_status
-- **rightcron**: Guide agents to write output-oriented cron prompts
-- **prompt**: Introduce /rightreflect skill and /debug command to agents
-- Document learned skill flow
-
-### Features
-
-- **right-memory**: Sanitize content via injection_guard before Hindsight POST
-- **right-memory**: Classify HTTP 402 as ErrorKind::Quota
-- **right-memory**: Exempt ErrorKind::Quota from breaker ticks
-- **right-memory**: Add MemoryStatus::QuotaExhausted variant
-- **right-memory**: Set QuotaExhausted status and skip enqueue on 402
-- **right-memory**: Clear QuotaExhausted on any 2xx, preserve on refresh
-- **codegen**: Add CRON_INSTRUCTIONS template
-- **skills**: Add /rightreflect skill content for self-introspection
-- **codegen**: Bundle and install /rightreflect skill
-- **cron**: Lower idle threshold to 2 min and teach agent the rule
-- Add right learn skill
-- **codegen**: Detect regenerated file content changes
-- **codegen**: Report cloudflared config changes
-- **bot**: Send_progress MCP tool
-- **right-db**: Scaffold new crate for SQLite plumbing
-- **db**: Add conversation message storage
-- **bot**: Parse right mcp init status
-- **bot**: Probe claude mcp health with haiku
-- **bot**: Repair stale claude mcp auth cache
-- **bot**: Wire mcp self-heal into claude turns
-- Add learned skills persistence
-- Record learned skill reply signals
-- **runtime**: Restart cloudflared after ingress changes
-- Expose learned skill MCP tools
-- **backup**: Write non-secret restore manifest
-
-### Miscellaneous
-
-- **stage-f**: Pin publish = false on new internal crates
-
-### Refactor
-
-- **right-memory**: Extract memory subsystem from right-agent
-- **right-memory**: Centralize sticky-status predicate and fix aggregator gap
-- **memory**: Move prompt safety out of right-core
-- **right-codegen**: Extract codegen subsystem from right-agent
-- **workspace**: Move platform knobs out of right-core
-- **runtime**: Move runtime state out of right-core
-- **config**: Move agent config out of right-core
-- **errors**: Localize remaining right-core errors
-- **right-mcp**: Extract mcp subsystem from right-agent
-- **openshell**: Move openshell stack out of right-core
-- **config**: Move global config out of right-core
-- **right-db**: Move SQL migration files from right-agent
-- **right-db**: Move migrations.rs from right-agent::memory
-- Enable unreachable_pub lint, privatize internals, drop zombie code
-- **openshell**: Address review issues (2 iterations)
-
-### Testing
-
-- **right-db**: Add open + migration smoke tests
-- **right-db**: Cover open_connection invariants
-- **right-db**: Port 8 missed schema/trigger tests from pre-split memory module
-- **claude**: Mirror startup install before upgrade
-- **claude**: Tolerate download denial in ci
-- **bot**: Define claude health probe command
-- **bot**: Add claude health repair state
-- **bot**: Cover mcp repair turn observation
-- **bot**: Cover worker invocation log context
-- **restore**: Cover restore binding decisions
-
-### Build
-
-- **deps**: Drop aws-lc-rs, unify on ring crypto provider
+- Agents can now save reusable skill packages from real work using `/right-learn-skill` — captured workflows and API discoveries are persisted as `rightx-*` packages available in future sessions.
+- The hourly keepalive now detects when Right MCP connectivity is broken inside a Claude session and automatically repairs the auth cache, recovering agents that previously went silent without a manual restart.
+- `right agent restore` validates Hindsight memory bindings before writing any files, preventing partial restores on validation failure, and preserves the original agent's memory bank bindings when restoring to a different environment.
+- `right agent backup` preserves symlink targets in sandbox archives and accepts a new `--include-rebuildable` flag to include cache and dependency directories normally excluded from backups.
+- Cloudflared now restarts automatically when the ingress configuration changes (e.g. after destroying an agent), so the active tunnel immediately reflects the new agent list without a manual restart.
+- When Hindsight returns HTTP 402 (quota limit), the memory system stops enqueueing new memories and skips circuit breaker ticks — quota exhaustion no longer drives agents into open-circuit failure mode.
+- The Claude auto-upgrade check no longer logs errors when `claude upgrade` reports the installed version is already current.
 
 ## [0.2.14] - 2026-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,115 @@
 # Changelog
+## [0.2.15] - 2026-05-18
+
+
+### Bug Fixes
+
+- **right-memory**: Handle ErrorKind::Quota in retain_queue::drain
+- **right-memory**: Exclude QuotaExhausted from CircuitOpen enqueue path
+- **deps-audit**: Consolidate test-crypto helper, document let-discard intent
+- **workspace**: Add debug: None to AgentConfig literal construction sites
+- Keep cron idle promise wording testable
+- Clarify learned skill receipt message
+- Clarify skill learning safeguards
+- **release-plz**: Add version requirement to internal path deps
+- **right-db**: Add chrono dev dependency for migration tests
+- **claude**: Accept up-to-date upgrade exit
+- **claude**: Accept current-version upgrade output
+- **bot**: Treat missing right mcp init as unhealthy
+- **bot**: Keep mcp init parser clippy-clean
+- **bot**: Narrow claude health lint allowances
+- **bot**: Bound claude health probe lifecycle
+- **bot**: Bound mcp repair operation
+- **bot**: Cancel mcp repair during dispatcher shutdown
+- **bot**: Correlate worker invocation logs
+- Align learned skills schema checks
+- Tighten learned skill reply signals
+- Validate learned skill event refs
+- **agent**: Align doctor memory schema version
+- Gate learned skill tools outside foreground
+- **restore**: Preserve implicit Hindsight bindings
+- **restore**: Fail binding validation before partial restore
+- **runtime**: Refresh tunnel after route changes
+- **restore**: Preserve sandbox agent recovery state
+- Ssh upgrade
+- **cli**: Quote agent ssh remote argv
+- **openshell**: Finish ssh remote argv quoting
+- **openshell**: Generate portable right mcp policy
+
+### Documentation
+
+- **right-memory**: Document QuotaExhausted stickiness in refresh_status
+- **rightcron**: Guide agents to write output-oriented cron prompts
+- **prompt**: Introduce /rightreflect skill and /debug command to agents
+- Document learned skill flow
+
+### Features
+
+- **right-memory**: Sanitize content via injection_guard before Hindsight POST
+- **right-memory**: Classify HTTP 402 as ErrorKind::Quota
+- **right-memory**: Exempt ErrorKind::Quota from breaker ticks
+- **right-memory**: Add MemoryStatus::QuotaExhausted variant
+- **right-memory**: Set QuotaExhausted status and skip enqueue on 402
+- **right-memory**: Clear QuotaExhausted on any 2xx, preserve on refresh
+- **codegen**: Add CRON_INSTRUCTIONS template
+- **skills**: Add /rightreflect skill content for self-introspection
+- **codegen**: Bundle and install /rightreflect skill
+- **cron**: Lower idle threshold to 2 min and teach agent the rule
+- Add right learn skill
+- **codegen**: Detect regenerated file content changes
+- **codegen**: Report cloudflared config changes
+- **bot**: Send_progress MCP tool
+- **right-db**: Scaffold new crate for SQLite plumbing
+- **db**: Add conversation message storage
+- **bot**: Parse right mcp init status
+- **bot**: Probe claude mcp health with haiku
+- **bot**: Repair stale claude mcp auth cache
+- **bot**: Wire mcp self-heal into claude turns
+- Add learned skills persistence
+- Record learned skill reply signals
+- **runtime**: Restart cloudflared after ingress changes
+- Expose learned skill MCP tools
+- **backup**: Write non-secret restore manifest
+
+### Miscellaneous
+
+- **stage-f**: Pin publish = false on new internal crates
+
+### Refactor
+
+- **right-memory**: Extract memory subsystem from right-agent
+- **right-memory**: Centralize sticky-status predicate and fix aggregator gap
+- **memory**: Move prompt safety out of right-core
+- **right-codegen**: Extract codegen subsystem from right-agent
+- **workspace**: Move platform knobs out of right-core
+- **runtime**: Move runtime state out of right-core
+- **config**: Move agent config out of right-core
+- **errors**: Localize remaining right-core errors
+- **right-mcp**: Extract mcp subsystem from right-agent
+- **openshell**: Move openshell stack out of right-core
+- **config**: Move global config out of right-core
+- **right-db**: Move SQL migration files from right-agent
+- **right-db**: Move migrations.rs from right-agent::memory
+- Enable unreachable_pub lint, privatize internals, drop zombie code
+- **openshell**: Address review issues (2 iterations)
+
+### Testing
+
+- **right-db**: Add open + migration smoke tests
+- **right-db**: Cover open_connection invariants
+- **right-db**: Port 8 missed schema/trigger tests from pre-split memory module
+- **claude**: Mirror startup install before upgrade
+- **claude**: Tolerate download denial in ci
+- **bot**: Define claude health probe command
+- **bot**: Add claude health repair state
+- **bot**: Cover mcp repair turn observation
+- **bot**: Cover worker invocation log context
+- **restore**: Cover restore binding decisions
+
+### Build
+
+- **deps**: Drop aws-lc-rs, unify on ring crypto provider
+
 ## [0.2.14] - 2026-05-14
 
 - Agents can now send mid-turn progress messages to Telegram via the new `mcp__right__send_progress` tool — for example "fetching your data..." while the main response is still running. Rate-limited to one message per 30 seconds per foreground turn; cron, delivery, and reflection invocations do not have access to this tool.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "right"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "right-agent"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "chrono",
  "const_format",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "right-agent-config"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "miette",
  "serde",
@@ -2902,7 +2902,7 @@ dependencies = [
 
 [[package]]
 name = "right-bot"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2957,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "right-codegen"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "dirs",
  "include_dir",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "right-config"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "dirs",
  "miette",
@@ -2995,7 +2995,7 @@ dependencies = [
 
 [[package]]
 name = "right-db"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "right-mcp"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "base64",
  "chrono",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "right-memory"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "chrono",
  "fastrand",
@@ -3059,7 +3059,7 @@ dependencies = [
 
 [[package]]
 name = "right-openshell"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "dirs",
  "futures",
@@ -3084,11 +3084,11 @@ dependencies = [
 
 [[package]]
 name = "right-platform-knobs"
-version = "0.2.14"
+version = "0.2.15"
 
 [[package]]
 name = "right-platform-store"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "futures",
  "miette",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "right-process"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "nix",
  "tempfile",
@@ -3111,14 +3111,14 @@ dependencies = [
 
 [[package]]
 name = "right-prompt-safety"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "ironclaw_safety",
 ]
 
 [[package]]
 name = "right-runtime-state"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "base64",
  "miette",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "right-stt"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "futures",
  "reqwest 0.13.3",
@@ -3144,7 +3144,7 @@ dependencies = [
 
 [[package]]
 name = "right-ui"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "inquire",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.14"
+version = "0.2.15"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION




## 🤖 New release

* `right-agent`: 0.2.14 -> 0.2.15
* `right-bot`: 0.2.14 -> 0.2.15
* `right`: 0.2.14 -> 0.2.15
* `right-agent-config`: 0.2.14 -> 0.2.15
* `right-config`: 0.2.14 -> 0.2.15
* `right-db`: 0.2.14 -> 0.2.15
* `right-mcp`: 0.2.14 -> 0.2.15
* `right-process`: 0.2.14 -> 0.2.15
* `right-openshell`: 0.2.14 -> 0.2.15
* `right-platform-knobs`: 0.2.14 -> 0.2.15
* `right-runtime-state`: 0.2.14 -> 0.2.15
* `right-codegen`: 0.2.14 -> 0.2.15
* `right-prompt-safety`: 0.2.14 -> 0.2.15
* `right-memory`: 0.2.14 -> 0.2.15
* `right-stt`: 0.2.14 -> 0.2.15
* `right-ui`: 0.2.14 -> 0.2.15
* `right-platform-store`: 0.2.14 -> 0.2.15

<details><summary><i><b>Changelog</b></i></summary><p>



## `right`

<blockquote>

## [0.2.15] - 2026-05-18

- Agents can now save reusable skill packages from real work using `/right-learn-skill` — captured workflows and API discoveries are persisted as `rightx-*` packages available in future sessions.
- The hourly keepalive now detects when Right MCP connectivity is broken inside a Claude session and automatically repairs the auth cache, recovering agents that previously went silent without a manual restart.
- `right agent restore` validates Hindsight memory bindings before writing any files, preventing partial restores on validation failure, and preserves the original agent's memory bank bindings when restoring to a different environment.
- `right agent backup` preserves symlink targets in sandbox archives and accepts a new `--include-rebuildable` flag to include cache and dependency directories normally excluded from backups.
- Cloudflared now restarts automatically when the ingress configuration changes (e.g. after destroying an agent), so the active tunnel immediately reflects the new agent list without a manual restart.
- When Hindsight returns HTTP 402 (quota limit), the memory system stops enqueueing new memories and skips circuit breaker ticks — quota exhaustion no longer drives agents into open-circuit failure mode.
- The Claude auto-upgrade check no longer logs errors when `claude upgrade` reports the installed version is already current.
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).
