### PR TITLE
fix(prompt): emit skill receipt message in reply language

### DIFF
--- a/PROMPT_SYSTEM.md
+++ b/PROMPT_SYSTEM.md
@@ -509,10 +509,13 @@ It NEVER deletes a skill. Constant is `right_codegen::CURATOR_SYSTEM_PROMPT`.
 
 Every reply MUST include `used_skill_receipts` (array, possibly empty).
 Each entry has `package_name` (pattern `^rightx-`) and `message`
-(minLength 1). The worker filters non-rightx package_names and renders
-each entry as `\n\n💡 <message> (<code><package_name></code>)` after the
-assistant's content, and records `use_count` + `last_used_at` for the named
-skill in the skill lifecycle database.
+(minLength 1). The `message` is authored in the same language as the reply
+`content` (enforced by prose in `OPERATING_INSTRUCTIONS.md`, not the schema —
+no schema field carries a `description`). The worker filters non-rightx
+package_names and renders each entry as
+`\n\n💡 <message> (<code><package_name></code>)` after the assistant's
+content, and records `use_count` + `last_used_at` for the named skill in the
+skill lifecycle database.
 
 ## MCP Server Instructions
 

--- a/crates/right-codegen/templates/right/prompt/OPERATING_INSTRUCTIONS.md
+++ b/crates/right-codegen/templates/right/prompt/OPERATING_INSTRUCTIONS.md
@@ -38,8 +38,9 @@ You MUST always include `used_skill_receipts` in your reply. Use an empty array
 `[]` if no `rightx-*` skill materially guided your answer. When one or more
 `rightx-*` skills did guide your answer, include one entry per skill. The
 `message` field describes the workflow you applied (e.g. "Built and verified
-npm package", not "Done") and is shown to the user. Do not emit receipts for
-built-in skills, core skills, or trivial mentions.
+npm package", not "Done"), is shown to the user, and MUST be written in the
+same language as your `content` reply. Do not emit receipts for built-in
+skills, core skills, or trivial mentions.
 
 ## MCP Management
 


### PR DESCRIPTION
## Problem

The per-turn `used_skill_receipts` `message`, rendered after the reply as `💡 <message> (rightx-*)`, was authored in whatever language the agent picked. Result: English receipts appended under Russian replies (e.g. `💡 Diagnosed: … (rightx-typefully)` under a Russian message).

Nothing in the prompt tier or schema required the receipt language to match the reply. `SKILL.md` said "localized" but it only loads on explicit `/right-learn-skill` invocation, not on normal per-turn receipt emission.

## Fix

- `OPERATING_INSTRUCTIONS.md` (per-turn system prompt): `message` MUST be written in the same language as the `content` reply.
- `PROMPT_SYSTEM.md`: synced to document the rule and note it's enforced by prose, not a schema `description` (the schema carries no field descriptions, so adding one only to `message` would be inconsistent and duplicate the rule).

Chose the prose-only fix over a schema `description` to respect the prompt-tier brevity / no-duplication convention.

## Verification

`cargo test -p right-codegen operating_instructions` — 9/9 pass; all receipt-rule needles intact.