### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 # Changelog
+## [0.3.1] - 2026-06-05
+
+
+### Bug Fixes
+
+- **openshell**: Read sandbox phase from SandboxStatus (0.0.56 relocation)
+
+### Features
+
+- **dashboard**: Compute usage windows in viewer timezone
+- **dashboard**: Accept usage timezone query
+
 ## [0.3.0] - 2026-06-04
 
 ### Learning & Skills

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3736,7 +3736,7 @@ dependencies = [
 
 [[package]]
 name = "right"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "right-agent"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "const_format",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "right-agent-config"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "miette",
  "serde",
@@ -3837,7 +3837,7 @@ dependencies = [
 
 [[package]]
 name = "right-bot"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3899,7 +3899,7 @@ dependencies = [
 
 [[package]]
 name = "right-codegen"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "dirs",
  "include_dir",
@@ -3926,7 +3926,7 @@ dependencies = [
 
 [[package]]
 name = "right-config"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "dirs",
  "miette",
@@ -3939,7 +3939,7 @@ dependencies = [
 
 [[package]]
 name = "right-dashboard"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -3963,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "right-db"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "fs4 1.1.0",
@@ -3978,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "right-hostpath"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tempfile",
  "thiserror 2.0.18",
@@ -3986,7 +3986,7 @@ dependencies = [
 
 [[package]]
 name = "right-lifecycle"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "right-db",
@@ -3999,7 +3999,7 @@ dependencies = [
 
 [[package]]
 name = "right-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "axum",
  "base64",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "right-memory"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "fastrand",
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "right-openshell"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -4080,11 +4080,11 @@ dependencies = [
 
 [[package]]
 name = "right-platform-knobs"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "right-platform-store"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "futures",
  "miette",
@@ -4097,7 +4097,7 @@ dependencies = [
 
 [[package]]
 name = "right-process"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "nix",
  "tempfile",
@@ -4107,14 +4107,14 @@ dependencies = [
 
 [[package]]
 name = "right-prompt-safety"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ironclaw_safety",
 ]
 
 [[package]]
 name = "right-runtime-state"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64",
  "miette",
@@ -4126,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "right-stt"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "futures",
  "reqwest 0.13.4",
@@ -4140,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "right-ui"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "inquire",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION



## 🤖 New release

* `right-agent`: 0.3.0 -> 0.3.1
* `right-bot`: 0.3.0 -> 0.3.1
* `right`: 0.3.0 -> 0.3.1
* `right-agent-config`: 0.3.0 -> 0.3.1
* `right-config`: 0.3.0 -> 0.3.1
* `right-db`: 0.3.0 -> 0.3.1
* `right-mcp`: 0.3.0 -> 0.3.1
* `right-process`: 0.3.0 -> 0.3.1
* `right-openshell`: 0.3.0 -> 0.3.1
* `right-platform-knobs`: 0.3.0 -> 0.3.1
* `right-runtime-state`: 0.3.0 -> 0.3.1
* `right-codegen`: 0.3.0 -> 0.3.1
* `right-prompt-safety`: 0.3.0 -> 0.3.1
* `right-memory`: 0.3.0 -> 0.3.1
* `right-stt`: 0.3.0 -> 0.3.1
* `right-ui`: 0.3.0 -> 0.3.1
* `right-lifecycle`: 0.3.0 -> 0.3.1
* `right-dashboard`: 0.3.0 -> 0.3.1
* `right-platform-store`: 0.3.0 -> 0.3.1
* `right-hostpath`: 0.3.0 -> 0.3.1

<details><summary><i><b>Changelog</b></i></summary><p>



## `right`

<blockquote>

## [0.3.1] - 2026-06-05

### Bug Fixes

- **openshell**: Read sandbox phase from SandboxStatus (0.0.56 relocation)

### Features

- **dashboard**: Compute usage windows in viewer timezone
- **dashboard**: Accept usage timezone query
</blockquote>



















</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).