### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,43 +1,9 @@
 # Changelog
 ## [0.3.2] - 2026-06-05
 
+- Provider credentials are now reliably injected in long-running sandboxes. Previously, the `right-github` provider's composed OpenShell policy was never confirmed loaded in the running sandbox — credentials fell through to the raw tunnel rule and were sent as the literal placeholder string, causing 401 errors from GitHub. Generic providers were also folded directly into `policy.yaml` as a separate source of truth. All providers now use OpenShell profile-backed gateway composition, and `right up` confirms the composed policy is loaded in the sandbox after every provider attach or reconcile. Existing generic providers are migrated automatically on the next `right up`; no changes to `agent.yaml` are required.
 
-### Bug Fixes
-
-- **supervisor**: Degrade on sandbox Phase: Error, not just gateway loss
-- **sync**: Report sandbox failure to supervisor on sync-cycle failure
-- **supervisor**: Preserve SandboxError during recovery retries
-- **supervisor**: Classify starting sandboxes separately
-- **providers**: Validate generic profile provisioning inputs
-- **providers**: Keep generic provider profile ids stable and unique
-- **providers**: Rollback generic profile update failures
-- **providers**: Reload composition on reconcile failures
-
-### Documentation
-
-- **providers**: Align architecture with profile composition
-
-### Features
-
-- **providers**: Reconcile profiles before composition reload
-- **providers**: Provision authored profiles for generic providers on up
-- **providers**: Create generic providers from profiles
-
-### Miscellaneous
-
-- Update Cargo.toml dependencies
-
-### Refactor
-
-- **codegen**: Remove provider policy folding
-
-### Testing
-
-- **providers**: Regen drops legacy folded stanzas
-
-### Style
-
-- **fmt**: Apply rustfmt to provider composition follow-ups
+- The sandbox supervisor now reads the real OpenShell sandbox phase before deciding to degrade, not just gateway reachability. A sandbox in `Phase: Error` is surfaced as unavailable to users in Telegram rather than silently failing. Starting sandboxes are classified separately from running ones so they are not prematurely treated as ready, and error state is preserved through recovery retries instead of being discarded.
 
 ## [0.3.1] - 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,44 @@
 # Changelog
+## [0.3.2] - 2026-06-05
+
+
+### Bug Fixes
+
+- **supervisor**: Degrade on sandbox Phase: Error, not just gateway loss
+- **sync**: Report sandbox failure to supervisor on sync-cycle failure
+- **supervisor**: Preserve SandboxError during recovery retries
+- **supervisor**: Classify starting sandboxes separately
+- **providers**: Validate generic profile provisioning inputs
+- **providers**: Keep generic provider profile ids stable and unique
+- **providers**: Rollback generic profile update failures
+- **providers**: Reload composition on reconcile failures
+
+### Documentation
+
+- **providers**: Align architecture with profile composition
+
+### Features
+
+- **providers**: Reconcile profiles before composition reload
+- **providers**: Provision authored profiles for generic providers on up
+- **providers**: Create generic providers from profiles
+
+### Miscellaneous
+
+- Update Cargo.toml dependencies
+
+### Refactor
+
+- **codegen**: Remove provider policy folding
+
+### Testing
+
+- **providers**: Regen drops legacy folded stanzas
+
+### Style
+
+- **fmt**: Apply rustfmt to provider composition follow-ups
+
 ## [0.3.1] - 2026-06-05
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3736,7 +3736,7 @@ dependencies = [
 
 [[package]]
 name = "right"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "right-agent"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "const_format",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "right-agent-config"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "miette",
  "serde",
@@ -3837,7 +3837,7 @@ dependencies = [
 
 [[package]]
 name = "right-bot"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3899,7 +3899,7 @@ dependencies = [
 
 [[package]]
 name = "right-codegen"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "dirs",
  "include_dir",
@@ -3926,7 +3926,7 @@ dependencies = [
 
 [[package]]
 name = "right-config"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "dirs",
  "miette",
@@ -3939,7 +3939,7 @@ dependencies = [
 
 [[package]]
 name = "right-dashboard"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -3963,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "right-db"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "fs4 1.1.0",
@@ -3978,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "right-hostpath"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "tempfile",
  "thiserror 2.0.18",
@@ -3986,7 +3986,7 @@ dependencies = [
 
 [[package]]
 name = "right-lifecycle"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "right-db",
@@ -3999,7 +3999,7 @@ dependencies = [
 
 [[package]]
 name = "right-mcp"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "axum",
  "base64",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "right-memory"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "fastrand",
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "right-openshell"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -4080,11 +4080,11 @@ dependencies = [
 
 [[package]]
 name = "right-platform-knobs"
-version = "0.3.1"
+version = "0.3.2"
 
 [[package]]
 name = "right-platform-store"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "futures",
  "miette",
@@ -4097,7 +4097,7 @@ dependencies = [
 
 [[package]]
 name = "right-process"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "nix",
  "tempfile",
@@ -4107,14 +4107,14 @@ dependencies = [
 
 [[package]]
 name = "right-prompt-safety"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "ironclaw_safety",
 ]
 
 [[package]]
 name = "right-runtime-state"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "base64",
  "miette",
@@ -4126,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "right-stt"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "futures",
  "reqwest 0.13.4",
@@ -4140,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "right-ui"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "inquire",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION




## 🤖 New release

* `right-agent`: 0.3.1 -> 0.3.2
* `right-bot`: 0.3.1 -> 0.3.2
* `right`: 0.3.1 -> 0.3.2
* `right-agent-config`: 0.3.1 -> 0.3.2
* `right-config`: 0.3.1 -> 0.3.2
* `right-db`: 0.3.1 -> 0.3.2
* `right-mcp`: 0.3.1 -> 0.3.2
* `right-process`: 0.3.1 -> 0.3.2
* `right-openshell`: 0.3.1 -> 0.3.2
* `right-platform-knobs`: 0.3.1 -> 0.3.2
* `right-runtime-state`: 0.3.1 -> 0.3.2
* `right-codegen`: 0.3.1 -> 0.3.2
* `right-prompt-safety`: 0.3.1 -> 0.3.2
* `right-memory`: 0.3.1 -> 0.3.2
* `right-stt`: 0.3.1 -> 0.3.2
* `right-ui`: 0.3.1 -> 0.3.2
* `right-lifecycle`: 0.3.1 -> 0.3.2
* `right-dashboard`: 0.3.1 -> 0.3.2
* `right-platform-store`: 0.3.1 -> 0.3.2
* `right-hostpath`: 0.3.1 -> 0.3.2

<details><summary><i><b>Changelog</b></i></summary><p>



## `right`

<blockquote>

## [0.3.2] - 2026-06-05

- Provider credentials are now reliably injected in long-running sandboxes. Previously, the `right-github` provider's composed OpenShell policy was never confirmed loaded in the running sandbox — credentials fell through to the raw tunnel rule and were sent as the literal placeholder string, causing 401 errors from GitHub. Generic providers were also folded directly into `policy.yaml` as a separate source of truth. All providers now use OpenShell profile-backed gateway composition, and `right up` confirms the composed policy is loaded in the sandbox after every provider attach or reconcile. Existing generic providers are migrated automatically on the next `right up`; no changes to `agent.yaml` are required.

- The sandbox supervisor now reads the real OpenShell sandbox phase before deciding to degrade, not just gateway reachability. A sandbox in `Phase: Error` is surfaced as unavailable to users in Telegram rather than silently failing. Starting sandboxes are classified separately from running ones so they are not prematurely treated as ready, and error state is preserved through recovery retries instead of being discarded.
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).
