### PR TITLE
ci(openshell): open revendor PR only on real proto change

### DIFF
--- a/.github/workflows/humanize-changelog.yml
+++ b/.github/workflows/humanize-changelog.yml
@@ -88,3 +88,36 @@ jobs:
           claude_args: |
             --model sonnet
             --allowedTools Edit,Read,Write,Bash
+
+      - name: Signal completion
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # GitHub has no checkmark reaction; +1 is the conventional "done" mark.
+          gh api -X POST \
+            "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content=+1 >/dev/null || true
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" \
+            --body "✅ \`/humanize\` complete — changelog humanized and pushed to this PR. ([run](${RUN_URL}))" \
+            || true
+
+      - name: Signal failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh api -X POST \
+            "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content=confused >/dev/null || true
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" \
+            --body "⚠️ \`/humanize\` failed — see the [workflow run](${RUN_URL}) logs." \
+            || true

--- a/.github/workflows/openshell-proto-compat.yml
+++ b/.github/workflows/openshell-proto-compat.yml
@@ -4,6 +4,13 @@ name: OpenShell proto compat
 # `buf breaking` + `cargo check`, and open/update a single PR so upstream
 # wire/API drift is caught before it reaches a running gateway. It SURFACES
 # only — a human fixes any Rust decode logic and bumps version floors.
+#
+# A PR is opened ONLY when the vendored `.proto` files actually change. The
+# vendor script rewrites UPSTREAM.md's `fetched:` timestamp on every run, so
+# gating on that file alone would open a no-op PR daily even for a
+# wire-identical upstream release (e.g. v0.0.56 → v0.0.57 with no proto diff).
+# The gate below checks `proto/openshell/**` against HEAD and skips the compat
+# check + PR entirely when only the metadata moved.
 on:
   workflow_dispatch:
   schedule:
@@ -48,13 +55,31 @@ jobs:
           TAG: ${{ steps.resolve.outputs.tag }}
         run: bash scripts/vendor-openshell-proto.sh "$TAG"
 
+      # Gate on the actual vendored protos, NOT UPSTREAM.md. The vendor script
+      # rewrites UPSTREAM.md's `fetched:` timestamp every run, so a diff there is
+      # not a signal. UPSTREAM.md lives one level above proto/openshell, so this
+      # check excludes it and detects only real wire/API drift.
+      - name: Detect actual proto change
+        id: gate
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- crates/right-openshell/proto/openshell; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No .proto changes vs committed — only UPSTREAM.md metadata moved. Skipping compat check + PR."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Detected .proto changes — running compat check and opening/updating PR."
+          fi
+
       - name: Setup buf
+        if: steps.gate.outputs.changed == 'true'
         uses: bufbuild/buf-setup-action@v1
         with:
           github_token: ${{ github.token }}
 
       - name: buf breaking (PACKAGE)
         id: buf
+        if: steps.gate.outputs.changed == 'true'
         continue-on-error: true
         run: |
           set -uo pipefail
@@ -68,16 +93,20 @@ jobs:
           echo "--- buf breaking output ---"
           cat /tmp/buf-breaking.txt || true
 
-      - uses: cachix/install-nix-action@v31
+      - if: steps.gate.outputs.changed == 'true'
+        uses: cachix/install-nix-action@v31
       - name: Install devenv.sh
+        if: steps.gate.outputs.changed == 'true'
         run: nix profile add nixpkgs#devenv
-      - uses: Swatinem/rust-cache@v2
+      - if: steps.gate.outputs.changed == 'true'
+        uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> target/devenv"
           cmd-format: devenv shell -- {0}
 
       - name: cargo check (regenerates stubs from the new proto)
         id: check
+        if: steps.gate.outputs.changed == 'true'
         continue-on-error: true
         run: |
           set -uo pipefail
@@ -91,6 +120,7 @@ jobs:
           tail -60 /tmp/cargo-check.txt || true
 
       - name: Compose PR body
+        if: steps.gate.outputs.changed == 'true'
         env:
           TAG: ${{ steps.resolve.outputs.tag }}
           BUF_RESULT: ${{ steps.buf.outputs.result }}
@@ -135,6 +165,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Create or update PR
+        if: steps.gate.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           branch: automation/openshell-proto-revendor

--- a/docs/superpowers/specs/2026-06-06-provider-capabilities-agent-visibility-design.md
+++ b/docs/superpowers/specs/2026-06-06-provider-capabilities-agent-visibility-design.md
@@ -1,0 +1,155 @@
+# Provider-capabilities visibility for the agent
+
+**Date:** 2026-06-06
+**Status:** Design approved, pending spec review
+
+## Problem
+
+A sandboxed agent sees provider credentials only as opaque placeholder env
+vars (e.g. `GITHUB_TOKEN=openshell:resolve:env:v…_GITHUB_TOKEN`). It has no
+way to know:
+
+1. that such an env var is a gateway-managed provider credential,
+2. which binaries are allowed to "cash in" the placeholder (the gateway
+   substitutes the real secret only for requests from the profile's
+   `binaries` allowlist hitting a TLS-terminated endpoint), and
+3. which hosts the credential is valid for.
+
+The built-in `right-github` profile scopes substitution to `gh`/`git` only.
+When the agent reaches `api.github.com` via a non-allowlisted binary
+(`curl`, `node` fetch, python), the request falls through to the permissive
+`outbound` raw tunnel where no substitution happens — the literal
+placeholder is sent and GitHub returns `401 Bad credentials`. The agent
+then **misdiagnoses** this as an expired PAT and asks the user to rotate the
+token, when in fact `gh`/`git` work and the credential is valid.
+
+### Confirmed diagnosis (agent `right`, sandbox `right-right-20260516-1640`)
+
+- `gh api user` → `200`, returns `right-bot`. Substitution works, PAT valid.
+- `git ls-remote https://github.com/onsails/right-agent` → success.
+- `curl https://api.github.com/user` → `401`. Binary not in the provider
+  rule's `binaries` list → routed via raw `outbound` tunnel → no injection.
+
+The effective policy already contains a correctly composed
+`_provider_right_right_github` rule (binaries `gh`/`git`, endpoints
+`api.github.com:443`, `github.com:443`). The bug is **agent knowledge**, not
+policy composition or credentials.
+
+The binary scoping is intentional and kept: it limits which sandbox
+processes can spend the GitHub token (a meaningful supply-chain boundary —
+e.g. a malicious `npm postinstall` cannot exfil via GitHub). The fix is to
+**teach the agent**, not widen the allowlist.
+
+## Goals
+
+- Give the agent a way to learn, for its own sandbox, which binaries can use
+  which credential and on which hosts.
+- Give the agent baseline conceptual understanding of the "provider" entity.
+- Stop the 401 → "bad credential" misdiagnosis.
+
+## Non-goals (YAGNI)
+
+- Broad policy introspection (full filesystem/network view) — a narrow
+  provider-capability tool only. Can be promoted later if a real need
+  appears.
+- Live credential validation (making a probe request).
+- Changing the OpenShell gateway's behavior when an unsubstituted
+  placeholder is sent (out of our control).
+- Widening the `right-github` `binaries` allowlist.
+
+## Design
+
+Hybrid: a thin pointer + conceptual note in the prompt, with accurate detail
+fetched on demand via a new MCP tool.
+
+### 1. New built-in MCP tool `mcp__right__provider_capabilities`
+
+- Read-only, routed to `RightBackend` (unprefixed built-in tool).
+- **Scope is server-enforced.** The agent supplies **no arguments** — not a
+  sandbox name, not a provider name. Scope resolves from the invocation
+  context, exactly like `thread_search` / `forum_topic_list`. The agent
+  cannot query another sandbox.
+- Returns the list of providers attached to the agent's own sandbox; per
+  provider:
+  - `display_name` — user-friendly name (e.g. "GitHub"), never raw slug.
+  - `env_vars` — names of placeholder env vars actually present in the
+    sandbox.
+  - `allowed_binaries` — binaries that can use the credential.
+  - `endpoint_hosts` — hosts the credential is valid for.
+  - `usage_hint` — one line, e.g. "Use `gh`/`git`; the gateway injects auth
+    on api.github.com/github.com. Do not put this env var into curl/fetch."
+- **Never** returns credential or placeholder *values* — only env-var names
+  and non-secret fields.
+
+### 2. Data source — effective policy (fact, not intent)
+
+A read helper lives in `right_openshell::providers`
+(`provider_capabilities_for_sandbox(sandbox)`), correlating three live
+sources:
+
+- **Effective sandbox policy** over gRPC → parse `_provider_<name>` network
+  rules → the `binaries` and `endpoint_hosts` that *actually* govern
+  requests right now (catches composition drift).
+- **`GetSandboxProviderEnvironment`** → the real placeholder env-var names
+  the sandbox currently sees.
+- **ListProviders / attachments + profile** → `display_name` and the
+  `_provider_<name>` ↔ provider correlation.
+
+Profile operations go through `right_openshell::managed_profiles`; policy
+read goes through `right_openshell::openshell`. No new convention bypasses.
+
+Reading the effective policy (not the authored profile) follows the
+project's "debuggability over convenience: use the direct observable signal"
+rule — composition drift is itself a plausible root cause of such 401s, so
+the factual slice is the more valuable one.
+
+### 3. Prompt (thin pointer + concept)
+
+In `OPERATING_INSTRUCTIONS.md`, within the prompt-tier brevity budget
+(2–3 sentences):
+
+- **Concept:** providers are gateway-managed credentials; in env they appear
+  as opaque placeholders; only specific binaries can use them on specific
+  hosts, and the gateway substitutes the secret on the outbound request; do
+  not paste a placeholder into arbitrary HTTP clients.
+- **Trigger:** on a `401`/`403` from a provider endpoint, call
+  `mcp__right__provider_capabilities` before concluding the credential is
+  invalid.
+
+Also: the tool's own description, the aggregator `with_instructions()` (per
+the MCP convention), and `PROMPT_SYSTEM.md` are kept in sync.
+
+### 4. Aggregator wiring
+
+- Register `provider_capabilities` in the `RightBackend` tool dispatch.
+- Update `with_instructions()` to list the tool and its description.
+- The tool resolves the agent's sandbox from the same per-invocation context
+  used by the other scoped tools — no agent-supplied scope.
+
+## Testing
+
+- **Unit:** parse `_provider_<name>` rules from a sample effective-policy
+  payload → correct `binaries` / `endpoint_hosts`; correlation
+  provider ↔ rule ↔ env-var.
+- **Live `ci_openshell_`:** attach a provider to a `TestSandbox`, call the
+  helper, assert the returned binaries/endpoints/env match the composed
+  policy. Reuse the generic-provider test harness
+  (`ci_openshell_generic_provider.rs`).
+- **MCP-level:** the tool scopes from context and rejects/ignores any
+  agent-supplied sandbox argument; never emits credential values.
+
+Cadence: targeted package tests during implementation; one
+`cargo test --workspace` at the end.
+
+## Security
+
+- Server-enforced scope to the agent's own sandbox; no agent-supplied
+  sandbox/provider arguments.
+- Zero write surface; read-only.
+- Credential/placeholder values never returned — only env-var names and
+  non-secret capability metadata.
+
+## Out of scope / explicitly deferred
+
+Broad policy introspection (B2), live credential validation, gateway error
+shaping, and any change to the `right-github` binary allowlist.


### PR DESCRIPTION
## Problem

The daily `OpenShell proto compat` workflow opened (or updated) a PR on **every** run, even when upstream shipped a wire-identical release. Root cause: `scripts/vendor-openshell-proto.sh` rewrites `UPSTREAM.md`'s `fetched:` timestamp on every run, and `create-pull-request`'s `add-paths: proto/**` includes that file — so a diff always exists.

Concrete example: #102 re-vendored v0.0.56 → v0.0.57 but the `.proto` files are **byte-identical**; only `tag:`/`fetched:` in `UPSTREAM.md` moved. (Closed as noise.)

## Fix

Add a `Detect actual proto change` gate that runs `git diff --quiet -- crates/right-openshell/proto/openshell`. `UPSTREAM.md` lives one level **above** `proto/openshell`, so it's excluded — only real wire/API drift trips the gate.

The compat steps (`buf breaking`, nix/devenv setup, `cargo check`, compose body, create PR) are now `if: steps.gate.outputs.changed == 'true'`. Wire-identical releases end the job green with a log line and open **no** PR. Real proto changes behave exactly as before (and the committed PR still carries the `UPSTREAM.md` tag bump alongside the proto diff).

Bonus: skips the slow nix + `cargo check` on no-op days.

actionlint: clean.