### PR TITLE
chore: release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,67 @@
 # Changelog
+## [0.3.3] - 2026-06-08
+
+
+### Bug Fixes
+
+- **worker**: Let all-mode group batches reach cc
+- **filter**: Keep all-mode bot loop guard through addressed fallback
+- **mention**: Topic-root service message is not a reply-to-bot
+- **bot**: Make response-mode callbacks scope-safe
+- **bot**: Publish locked allowlist updates in order
+- **bot**: Reuse prepared connection for reply gate
+- **providers**: Repair legacy generic provider types
+- **bot**: Report provider composition degradation
+- **cli**: Require opened group for mode clear
+- **providers**: Re-enable providers_v2_enabled at startup
+- **dashboard**: Confirm built-in provider composition before yaml write
+- **dashboard**: Confirm config-update provider composition
+- **providers**: Require generic endpoint content when confirming composition
+- **dashboard**: Report generic composition by endpoint content
+- **dashboard**: Distinguish unknown provider composition state
+- **providers**: Keep composition waits recoverable
+- **providers**: Detect composition via effective policy (GetSandboxConfig)
+- **providers**: Harden legacy generic repair
+
+### Documentation
+
+- **prompt**: Teach agent provider placeholder/binary model + 401 trigger
+- Document text vs truncated_text and reply context tiers
+- **mcp**: Advertise provider_capabilities in server instructions
+
+### Features
+
+- **right-db**: Session-context gate queries for reply rendering
+- **filter**: Respond-to-all mode gating per scope
+- **bot**: /mode and /mode_group inline-keyboard handlers
+- **bot**: Reply-render decision logic and constants
+- **bot**: Gate reply context before rendering
+- **supervisor**: Confirm provider composition after reload (bring-up + hot-reconcile)
+- **usage**: Select dashboard usage range server-side
+- **allowlist**: Effective response-mode lookup and setters
+- **mcp**: Add provider_capabilities built-in tool
+- **allowlist**: Response-mode schema v2 (addressed/all) with backward-compatible parse
+- **cli**: Right agent mode allowlist mirror
+- **stt**: Add `right stt preload` and prefetch model in CI
+- **dashboard**: Ensure and surface provider composition state
+
+### Performance
+
+- **filter**: Skip response-mode lookup for private chats
+
+### Refactor
+
+- **bot**: Group reply gate parameters
+
+### Testing
+
+- **usage**: Cover dashboard usage range query
+- **cli**: Cover response mode validation
+
+### Style
+
+- **clippy**: Clear workspace clippy gate under clippy 1.96
+
 ## [0.3.2] - 2026-06-05
 
 - Provider credentials are now reliably injected in long-running sandboxes. Previously, the `right-github` provider's composed OpenShell policy was never confirmed loaded in the running sandbox — credentials fell through to the raw tunnel rule and were sent as the literal placeholder string, causing 401 errors from GitHub. Generic providers were also folded directly into `policy.yaml` as a separate source of truth. All providers now use OpenShell profile-backed gateway composition, and `right up` confirms the composed policy is loaded in the sandbox after every provider attach or reconcile. Existing generic providers are migrated automatically on the next `right up`; no changes to `agent.yaml` are required.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3736,7 +3736,7 @@ dependencies = [
 
 [[package]]
 name = "right"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "right-agent"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "const_format",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "right-agent-config"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "miette",
  "serde",
@@ -3837,7 +3837,7 @@ dependencies = [
 
 [[package]]
 name = "right-bot"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3899,7 +3899,7 @@ dependencies = [
 
 [[package]]
 name = "right-codegen"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "dirs",
  "include_dir",
@@ -3926,7 +3926,7 @@ dependencies = [
 
 [[package]]
 name = "right-config"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "dirs",
  "miette",
@@ -3939,7 +3939,7 @@ dependencies = [
 
 [[package]]
 name = "right-dashboard"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -3963,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "right-db"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "fs4 1.1.0",
@@ -3978,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "right-hostpath"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "tempfile",
  "thiserror 2.0.18",
@@ -3986,7 +3986,7 @@ dependencies = [
 
 [[package]]
 name = "right-lifecycle"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "right-db",
@@ -3999,7 +3999,7 @@ dependencies = [
 
 [[package]]
 name = "right-mcp"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "axum",
  "base64",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "right-memory"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "fastrand",
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "right-openshell"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "dirs",
@@ -4080,11 +4080,11 @@ dependencies = [
 
 [[package]]
 name = "right-platform-knobs"
-version = "0.3.2"
+version = "0.3.3"
 
 [[package]]
 name = "right-platform-store"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "futures",
  "miette",
@@ -4097,7 +4097,7 @@ dependencies = [
 
 [[package]]
 name = "right-process"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "nix",
  "tempfile",
@@ -4107,14 +4107,14 @@ dependencies = [
 
 [[package]]
 name = "right-prompt-safety"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "ironclaw_safety",
 ]
 
 [[package]]
 name = "right-runtime-state"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "base64",
  "miette",
@@ -4126,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "right-stt"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "futures",
  "reqwest 0.13.4",
@@ -4140,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "right-ui"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "inquire",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION



## 🤖 New release

* `right-agent`: 0.3.2 -> 0.3.3
* `right-bot`: 0.3.2 -> 0.3.3
* `right`: 0.3.2 -> 0.3.3
* `right-agent-config`: 0.3.2 -> 0.3.3
* `right-config`: 0.3.2 -> 0.3.3
* `right-db`: 0.3.2 -> 0.3.3
* `right-mcp`: 0.3.2 -> 0.3.3
* `right-process`: 0.3.2 -> 0.3.3
* `right-openshell`: 0.3.2 -> 0.3.3
* `right-platform-knobs`: 0.3.2 -> 0.3.3
* `right-runtime-state`: 0.3.2 -> 0.3.3
* `right-codegen`: 0.3.2 -> 0.3.3
* `right-prompt-safety`: 0.3.2 -> 0.3.3
* `right-memory`: 0.3.2 -> 0.3.3
* `right-stt`: 0.3.2 -> 0.3.3
* `right-ui`: 0.3.2 -> 0.3.3
* `right-lifecycle`: 0.3.2 -> 0.3.3
* `right-dashboard`: 0.3.2 -> 0.3.3
* `right-platform-store`: 0.3.2 -> 0.3.3
* `right-hostpath`: 0.3.2 -> 0.3.3

<details><summary><i><b>Changelog</b></i></summary><p>



## `right`

<blockquote>

## [0.3.3] - 2026-06-08

### Bug Fixes

- **worker**: Let all-mode group batches reach cc
- **filter**: Keep all-mode bot loop guard through addressed fallback
- **mention**: Topic-root service message is not a reply-to-bot
- **bot**: Make response-mode callbacks scope-safe
- **bot**: Publish locked allowlist updates in order
- **bot**: Reuse prepared connection for reply gate
- **providers**: Repair legacy generic provider types
- **bot**: Report provider composition degradation
- **cli**: Require opened group for mode clear
- **providers**: Re-enable providers_v2_enabled at startup
- **dashboard**: Confirm built-in provider composition before yaml write
- **dashboard**: Confirm config-update provider composition
- **providers**: Require generic endpoint content when confirming composition
- **dashboard**: Report generic composition by endpoint content
- **dashboard**: Distinguish unknown provider composition state
- **providers**: Keep composition waits recoverable
- **providers**: Detect composition via effective policy (GetSandboxConfig)
- **providers**: Harden legacy generic repair

### Documentation

- **prompt**: Teach agent provider placeholder/binary model + 401 trigger
- Document text vs truncated_text and reply context tiers
- **mcp**: Advertise provider_capabilities in server instructions

### Features

- **right-db**: Session-context gate queries for reply rendering
- **filter**: Respond-to-all mode gating per scope
- **bot**: /mode and /mode_group inline-keyboard handlers
- **bot**: Reply-render decision logic and constants
- **bot**: Gate reply context before rendering
- **supervisor**: Confirm provider composition after reload (bring-up + hot-reconcile)
- **usage**: Select dashboard usage range server-side
- **allowlist**: Effective response-mode lookup and setters
- **mcp**: Add provider_capabilities built-in tool
- **allowlist**: Response-mode schema v2 (addressed/all) with backward-compatible parse
- **cli**: Right agent mode allowlist mirror
- **stt**: Add `right stt preload` and prefetch model in CI
- **dashboard**: Ensure and surface provider composition state

### Performance

- **filter**: Skip response-mode lookup for private chats

### Refactor

- **bot**: Group reply gate parameters

### Testing

- **usage**: Cover dashboard usage range query
- **cli**: Cover response mode validation

### Style

- **clippy**: Clear workspace clippy gate under clippy 1.96
</blockquote>



















</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).