### PR TITLE
chore: release v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 # Changelog
+## [0.3.4] - 2026-06-10
+
+
+### Bug Fixes
+
+- **bot**: Tolerate pending MCP health
+
+### Features
+
+- **prompt**: Make subagent model:sonnet the default for mechanical work
+
 ## [0.3.3] - 2026-06-08
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "right"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3796,7 +3796,7 @@ dependencies = [
 
 [[package]]
 name = "right-agent"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "const_format",
@@ -3836,7 +3836,7 @@ dependencies = [
 
 [[package]]
 name = "right-agent-config"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "miette",
  "serde",
@@ -3846,7 +3846,7 @@ dependencies = [
 
 [[package]]
 name = "right-bot"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "right-codegen"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "dirs",
  "include_dir",
@@ -3935,7 +3935,7 @@ dependencies = [
 
 [[package]]
 name = "right-config"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "dirs",
  "miette",
@@ -3948,7 +3948,7 @@ dependencies = [
 
 [[package]]
 name = "right-dashboard"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -3972,7 +3972,7 @@ dependencies = [
 
 [[package]]
 name = "right-db"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "fs4 1.1.0",
@@ -3987,7 +3987,7 @@ dependencies = [
 
 [[package]]
 name = "right-hostpath"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "tempfile",
  "thiserror 2.0.18",
@@ -3995,7 +3995,7 @@ dependencies = [
 
 [[package]]
 name = "right-lifecycle"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "right-db",
@@ -4008,7 +4008,7 @@ dependencies = [
 
 [[package]]
 name = "right-mcp"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "axum",
  "base64",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "right-memory"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "fastrand",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "right-openshell"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "dirs",
@@ -4089,11 +4089,11 @@ dependencies = [
 
 [[package]]
 name = "right-platform-knobs"
-version = "0.3.3"
+version = "0.3.4"
 
 [[package]]
 name = "right-platform-store"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "futures",
  "miette",
@@ -4106,7 +4106,7 @@ dependencies = [
 
 [[package]]
 name = "right-process"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "nix",
  "tempfile",
@@ -4116,14 +4116,14 @@ dependencies = [
 
 [[package]]
 name = "right-prompt-safety"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "ironclaw_safety",
 ]
 
 [[package]]
 name = "right-runtime-state"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "base64",
  "miette",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "right-stt"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "futures",
  "reqwest 0.13.4",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "right-ui"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "inquire",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION



## 🤖 New release

* `right-agent`: 0.3.3 -> 0.3.4
* `right-bot`: 0.3.3 -> 0.3.4
* `right`: 0.3.3 -> 0.3.4
* `right-agent-config`: 0.3.3 -> 0.3.4
* `right-config`: 0.3.3 -> 0.3.4
* `right-db`: 0.3.3 -> 0.3.4
* `right-mcp`: 0.3.3 -> 0.3.4
* `right-process`: 0.3.3 -> 0.3.4
* `right-openshell`: 0.3.3 -> 0.3.4
* `right-platform-knobs`: 0.3.3 -> 0.3.4
* `right-runtime-state`: 0.3.3 -> 0.3.4
* `right-codegen`: 0.3.3 -> 0.3.4
* `right-prompt-safety`: 0.3.3 -> 0.3.4
* `right-memory`: 0.3.3 -> 0.3.4
* `right-stt`: 0.3.3 -> 0.3.4
* `right-ui`: 0.3.3 -> 0.3.4
* `right-lifecycle`: 0.3.3 -> 0.3.4
* `right-dashboard`: 0.3.3 -> 0.3.4
* `right-platform-store`: 0.3.3 -> 0.3.4
* `right-hostpath`: 0.3.3 -> 0.3.4

<details><summary><i><b>Changelog</b></i></summary><p>



## `right`

<blockquote>

## [0.3.4] - 2026-06-10

### Bug Fixes

- **bot**: Tolerate pending MCP health

### Features

- **prompt**: Make subagent model:sonnet the default for mechanical work
</blockquote>



















</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).