### PR TITLE
fix(openshell): unbreak master + harden bot-PR safety net

### DIFF
--- a/.github/workflows/openshell-proto-compat.yml
+++ b/.github/workflows/openshell-proto-compat.yml
@@ -155,8 +155,11 @@ jobs:
             echo "A **BREAKING** or **FAILED** result means upstream changed the wire/API shape."
             echo "Audit \`SandboxReadiness\` and any code decoding moved/removed fields, then bump"
             echo "\`MIN_OPENSHELL_VERSION\` and the CI \`OPENSHELL_VERSION\` pin as needed."
-            echo "This bot surfaces drift only — it does not fix Rust. Full CI does not auto-run on"
-            echo "bot-authored PRs; push a commit (or re-run the Tests workflow) to trigger it."
+            echo "This bot surfaces drift only — it does not fix Rust. Full CI runs on this PR only"
+            echo "when \`BOT_PR_TOKEN\` (a fine-grained PAT) is configured as a repo secret;"
+            echo "otherwise bot-authored PRs don't trigger downstream workflows. Either way, the"
+            echo "\`openshell-proto-compat\` workflow run itself goes RED when \`cargo check\` fails,"
+            echo "so a failing proto bump is visible in the Actions tab even without full CI."
           } > /tmp/pr-body.md
           {
             echo "PR_BODY<<PRBODY_EOF"
@@ -168,6 +171,14 @@ jobs:
         if: steps.gate.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
+          # Prefer a fine-grained PAT so the PR is authored by a real account and
+          # the Tests workflow actually triggers on it (GitHub deliberately
+          # suppresses downstream workflow runs when an action is performed by
+          # GITHUB_TOKEN, to prevent loops). Falls back to GITHUB_TOKEN when the
+          # secret is not configured — in that case the PR is created but full
+          # CI must be triggered manually (or rely on the post-create gate
+          # below + the workflow's own RED status from a failing cargo check).
+          token: ${{ secrets.BOT_PR_TOKEN || github.token }}
           branch: automation/openshell-proto-revendor
           base: master
           title: "chore(openshell): re-vendor proto to ${{ steps.resolve.outputs.tag }}"
@@ -179,3 +190,15 @@ jobs:
             crates/right-openshell/proto/**
           commit-message: "chore(openshell): re-vendor proto to ${{ steps.resolve.outputs.tag }}"
           delete-branch: false
+
+      # Belt-and-suspenders: if cargo check failed against the new proto, fail
+      # the workflow run AFTER the PR has been created. This makes the failure
+      # visible in the Actions tab + via GitHub notifications, so a bot PR with
+      # a broken proto cannot quietly slip through (as v0.0.58 → master did).
+      # The PR itself stays open with the FAILED note in its body so the
+      # required Rust migration is obvious to a reviewer.
+      - name: Fail workflow if cargo check failed
+        if: steps.gate.outputs.changed == 'true' && steps.check.outputs.result == 'FAILED'
+        run: |
+          echo "::error::cargo check failed against the new proto — fix proto consumers (e.g. new fields on regenerated structs) before merging this PR."
+          exit 1

--- a/.github/workflows/openshell-proto-compat.yml
+++ b/.github/workflows/openshell-proto-compat.yml
@@ -95,8 +95,6 @@ jobs:
 
       - if: steps.gate.outputs.changed == 'true'
         uses: onsails/nix-action@v2.2.0
-        with:
-          additionalProfiles: 'nixpkgs#devenv'
       - if: steps.gate.outputs.changed == 'true'
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/openshell-proto-compat.yml
+++ b/.github/workflows/openshell-proto-compat.yml
@@ -19,6 +19,10 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Required for DeterminateSystems/flakehub-cache-action (transitively
+  # included by onsails/nix-action) to obtain a GitHub Actions OIDC token
+  # and authenticate against FlakeHub Cache.
+  id-token: write
 
 concurrency:
   group: openshell-proto-compat

--- a/.github/workflows/openshell-proto-compat.yml
+++ b/.github/workflows/openshell-proto-compat.yml
@@ -94,10 +94,9 @@ jobs:
           cat /tmp/buf-breaking.txt || true
 
       - if: steps.gate.outputs.changed == 'true'
-        uses: cachix/install-nix-action@v31
-      - name: Install devenv.sh
-        if: steps.gate.outputs.changed == 'true'
-        run: nix profile add nixpkgs#devenv
+        uses: onsails/nix-action@v2.2.0
+        with:
+          additionalProfiles: 'nixpkgs#devenv'
       - if: steps.gate.outputs.changed == 'true'
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,10 +27,39 @@ jobs:
       - uses: cachix/install-nix-action@v31
       - name: Install devenv.sh
         run: nix profile add nixpkgs#devenv
+      # Free ~25 GB on ubuntu-latest runners (default ~14 GB free, not enough
+      # for Nix + Cargo registry + restored target/devenv (~5 GB) + an
+      # incremental rebuild on top). Targets are pre-installed tooling we
+      # never use here (dotnet, Android SDK, GHC). Without this the cargo
+      # build hits ENOSPC partway through.
+      - name: Free up runner disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet \
+                      /usr/local/lib/android \
+                      /opt/ghc \
+                      /opt/hostedtoolcache/CodeQL \
+                      /usr/local/.ghcup
+          df -h /
+      - name: Disk usage before Rust cache
+        if: always()
+        run: |
+          df -h
+          du -sh target/devenv ~/.cargo /nix /tmp /home/runner/work 2>/dev/null || true
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> target/devenv"
           cmd-format: devenv shell -- {0}
+          # Stable per-job key (drops the auto-appended job suffix) so the
+          # cache entry is reused across PRs/pushes for the same lockfile.
+          # NOT shared with `ignored` — that job builds with
+          # `--features right-openshell/test-support`, so a shared target/
+          # would double-build many crates.
+          shared-key: "tests-workspace"
+      - name: Disk usage after Rust cache
+        if: always()
+        run: |
+          df -h
+          du -sh target/devenv ~/.cargo /nix /tmp /home/runner/work 2>/dev/null || true
 
       - name: Provide external-tool test stubs
         run: |
@@ -93,6 +122,17 @@ jobs:
       - uses: cachix/install-nix-action@v31
       - name: Install devenv.sh
         run: nix profile add nixpkgs#devenv
+      # Free ~25 GB on ubuntu-latest runners — same rationale as workspace job.
+      # The ignored job also installs OpenShell + Docker images later, so disk
+      # pressure is even higher here.
+      - name: Free up runner disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet \
+                      /usr/local/lib/android \
+                      /opt/ghc \
+                      /opt/hostedtoolcache/CodeQL \
+                      /usr/local/.ghcup
+          df -h /
       - name: Disk usage before Rust cache
         if: always()
         run: |
@@ -102,6 +142,10 @@ jobs:
         with:
           workspaces: ". -> target/devenv"
           cmd-format: devenv shell -- {0}
+          # Stable per-job key (drops the auto-appended job suffix) so the
+          # cache entry is reused across PRs/pushes for the same lockfile.
+          # NOT shared with `workspace` — see that job's shared-key comment.
+          shared-key: "tests-ignored"
       - name: Disk usage after Rust cache
         if: always()
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,16 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# id-token: write is required for DeterminateSystems/flakehub-cache-action
+# (transitively included by onsails/nix-action) to obtain a GitHub Actions
+# OIDC token and authenticate against FlakeHub Cache. Without it the cache
+# action prints "not authenticated" and falls back to degraded mode.
+# contents: read is the standard default — listed explicitly because
+# adding any permission narrows the implicit set to what is enumerated.
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   workspace:
     name: workspace tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,42 @@ jobs:
         run: |
           df -h
           du -sh target/devenv ~/.cargo /nix /tmp /home/runner/work 2>/dev/null || true
+      # TEMPORARY DIAGNOSTIC (remove after analysis): the rust-cache step below
+      # sits silent for ~12 min because its first `devenv shell -- cargo …`
+      # call is the first time the devenv environment is realized in the job.
+      # This step decomposes that cost: COLD (fresh eval + realize) vs
+      # EVAL-ONLY (eval cache dropped, store already realized) vs WARM (both
+      # cached). It also surfaces whether realize is download ("copying path")
+      # or source build ("building"). Side effect: warms the env so the
+      # rust-cache step that follows is fast.
+      - name: "DIAG decompose devenv shell cost"
+        run: |
+          set +e
+          nix --version
+          echo "::group::COLD devenv shell (fresh eval + realize)"
+          t=$SECONDS
+          devenv shell -- true > /tmp/cold.log 2>&1
+          echo "==> COLD: $((SECONDS - t))s"
+          tail -10 /tmp/cold.log
+          echo "::endgroup::"
+          echo "copying-path lines: $(grep -c 'copying path' /tmp/cold.log)"
+          echo "building lines:      $(grep -c 'building' /tmp/cold.log)"
+          echo "--- first downloads ---"
+          grep 'copying path' /tmp/cold.log | head -8
+          echo "--- builds (if any) ---"
+          grep 'building' /tmp/cold.log | head -20
+          echo "::group::EVAL-ONLY devenv shell (drop eval cache, store warm)"
+          rm -f .devenv/nix-eval-cache.db
+          t=$SECONDS
+          devenv shell -- true > /tmp/eval.log 2>&1
+          echo "==> EVAL-ONLY: $((SECONDS - t))s"
+          tail -5 /tmp/eval.log
+          echo "::endgroup::"
+          echo "::group::WARM devenv shell (eval cache + store warm)"
+          t=$SECONDS
+          devenv shell -- true > /tmp/warm.log 2>&1
+          echo "==> WARM: $((SECONDS - t))s"
+          echo "::endgroup::"
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> target/devenv"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,9 +24,13 @@ jobs:
       - uses: actions/checkout@v6
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v31
-      - name: Install devenv.sh
-        run: nix profile add nixpkgs#devenv
+      # onsails/nix-action installs Determinate Nix + Devenv + FlakeHub Cache
+      # in one step, with impatient-networking defaults (faster CI substituter
+      # retries) and parallel substitution. Replaces cachix/install-nix-action
+      # + a manual `nix profile add nixpkgs#devenv` step.
+      - uses: onsails/nix-action@v2.2.0
+        with:
+          additionalProfiles: 'nixpkgs#devenv'
       # Free ~25 GB on ubuntu-latest runners (default ~14 GB free, not enough
       # for Nix + Cargo registry + restored target/devenv (~5 GB) + an
       # incremental rebuild on top). Targets are pre-installed tooling we
@@ -119,9 +123,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v31
-      - name: Install devenv.sh
-        run: nix profile add nixpkgs#devenv
+      # Same Determinate Nix + Devenv + FlakeHub Cache combo as the workspace
+      # job. Replaces cachix/install-nix-action + manual devenv install.
+      - uses: onsails/nix-action@v2.2.0
+        with:
+          additionalProfiles: 'nixpkgs#devenv'
       # Free ~25 GB on ubuntu-latest runners — same rationale as workspace job.
       # The ignored job also installs OpenShell + Docker images later, so disk
       # pressure is even higher here.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,14 +57,29 @@ jobs:
         run: |
           df -h
           du -sh target/devenv ~/.cargo /nix /tmp /home/runner/work 2>/dev/null || true
-      # TEMPORARY DIAGNOSTIC (remove after analysis): the rust-cache step below
-      # sits silent for ~12 min because its first `devenv shell -- cargo …`
-      # call is the first time the devenv environment is realized in the job.
-      # This step decomposes that cost: COLD (fresh eval + realize) vs
-      # EVAL-ONLY (eval cache dropped, store already realized) vs WARM (both
-      # cached). It also surfaces whether realize is download ("copying path")
-      # or source build ("building"). Side effect: warms the env so the
-      # rust-cache step that follows is fast.
+      # The ~12 min of silence in the rust-cache step is the FIRST `devenv
+      # shell` in the job: fetching the flake inputs (cachix/devenv-nixpkgs
+      # rolling tarball + oxalica/rust-overlay) and the first full Nix
+      # evaluation. Neither FlakeHub nor magic-nix-cache (store caches) touch
+      # this — the cost is the eval layer, which lives in ~/.cache/nix (nix
+      # eval cache + fetched flake inputs) and .devenv (devenv's own eval DB +
+      # profile). Persist both, keyed on the lockfiles that pin the inputs.
+      # NOTE: .devenv here is devenv state, distinct from target/devenv (the
+      # cargo target dir cached by Swatinem/rust-cache) — do not conflate.
+      - name: Cache devenv eval layer
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/nix
+            .devenv
+          key: devenv-eval-${{ runner.os }}-${{ hashFiles('devenv.lock', 'devenv.nix', 'devenv.yaml') }}
+          restore-keys: |
+            devenv-eval-${{ runner.os }}-
+      # TEMPORARY DIAGNOSTIC (remove after analysis): decomposes the first
+      # devenv-shell cost into COLD (fresh eval + realize) vs EVAL-ONLY vs
+      # WARM, and surfaces download ("copying path") vs source build
+      # ("building"). Also serves as the warm-up: after this step the env is
+      # realized, so the rust-cache step's devenv calls are fast.
       - name: "DIAG decompose devenv shell cost"
         run: |
           set +e
@@ -181,6 +196,24 @@ jobs:
                       /opt/hostedtoolcache/CodeQL \
                       /usr/local/.ghcup
           df -h /
+      # Persist the devenv eval layer (nix eval cache + fetched flake inputs +
+      # devenv state) — same rationale as the workspace job. Without it the
+      # first devenv shell re-fetches inputs and re-evaluates from scratch on
+      # every run (~12 min). Keyed on the lockfiles that pin the inputs.
+      - name: Cache devenv eval layer
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/nix
+            .devenv
+          key: devenv-eval-${{ runner.os }}-${{ hashFiles('devenv.lock', 'devenv.nix', 'devenv.yaml') }}
+          restore-keys: |
+            devenv-eval-${{ runner.os }}-
+      # Warm the devenv environment once (cold on a cache miss, fast on a hit)
+      # so the rust-cache step's first `devenv shell -- cargo …` is not the one
+      # paying the realize cost.
+      - name: Warm devenv shell
+        run: devenv shell -- true
       - name: Disk usage before Rust cache
         if: always()
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,39 +75,15 @@ jobs:
           key: devenv-eval-${{ runner.os }}-${{ hashFiles('devenv.lock', 'devenv.nix', 'devenv.yaml') }}
           restore-keys: |
             devenv-eval-${{ runner.os }}-
-      # TEMPORARY DIAGNOSTIC (remove after analysis): decomposes the first
-      # devenv-shell cost into COLD (fresh eval + realize) vs EVAL-ONLY vs
-      # WARM, and surfaces download ("copying path") vs source build
-      # ("building"). Also serves as the warm-up: after this step the env is
-      # realized, so the rust-cache step's devenv calls are fast.
-      - name: "DIAG decompose devenv shell cost"
-        run: |
-          set +e
-          nix --version
-          echo "::group::COLD devenv shell (fresh eval + realize)"
-          t=$SECONDS
-          devenv shell -- true > /tmp/cold.log 2>&1
-          echo "==> COLD: $((SECONDS - t))s"
-          tail -10 /tmp/cold.log
-          echo "::endgroup::"
-          echo "copying-path lines: $(grep -c 'copying path' /tmp/cold.log)"
-          echo "building lines:      $(grep -c 'building' /tmp/cold.log)"
-          echo "--- first downloads ---"
-          grep 'copying path' /tmp/cold.log | head -8
-          echo "--- builds (if any) ---"
-          grep 'building' /tmp/cold.log | head -20
-          echo "::group::EVAL-ONLY devenv shell (drop eval cache, store warm)"
-          rm -f .devenv/nix-eval-cache.db
-          t=$SECONDS
-          devenv shell -- true > /tmp/eval.log 2>&1
-          echo "==> EVAL-ONLY: $((SECONDS - t))s"
-          tail -5 /tmp/eval.log
-          echo "::endgroup::"
-          echo "::group::WARM devenv shell (eval cache + store warm)"
-          t=$SECONDS
-          devenv shell -- true > /tmp/warm.log 2>&1
-          echo "==> WARM: $((SECONDS - t))s"
-          echo "::endgroup::"
+      # Warm the devenv environment once so the rust-cache step's first
+      # `devenv shell -- cargo …` is not the one paying the realize cost.
+      # With the eval cache restored above, the eval + flake-input fetch are
+      # skipped; the devenv closure (~4.3 GiB) still substitutes from
+      # cache.nixos.org on a fresh runner — an accepted cost (persisting the
+      # Nix store would need WarpBuild or exceed the 10 GB GHA cache budget
+      # already used by rust-cache).
+      - name: Warm devenv shell
+        run: devenv shell -- true
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> target/devenv"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,8 +29,6 @@ jobs:
       # retries) and parallel substitution. Replaces cachix/install-nix-action
       # + a manual `nix profile add nixpkgs#devenv` step.
       - uses: onsails/nix-action@v2.2.0
-        with:
-          additionalProfiles: 'nixpkgs#devenv'
       # Free ~25 GB on ubuntu-latest runners (default ~14 GB free, not enough
       # for Nix + Cargo registry + restored target/devenv (~5 GB) + an
       # incremental rebuild on top). Targets are pre-installed tooling we
@@ -126,8 +124,6 @@ jobs:
       # Same Determinate Nix + Devenv + FlakeHub Cache combo as the workspace
       # job. Replaces cachix/install-nix-action + manual devenv install.
       - uses: onsails/nix-action@v2.2.0
-        with:
-          additionalProfiles: 'nixpkgs#devenv'
       # Free ~25 GB on ubuntu-latest runners — same rationale as workspace job.
       # The ignored job also installs OpenShell + Docker images later, so disk
       # pressure is even higher here.

--- a/crates/right-openshell/src/managed_profiles.rs
+++ b/crates/right-openshell/src/managed_profiles.rs
@@ -153,6 +153,7 @@ pub fn author_generic_profile(
             header_name: header_name.to_string(),
             query_param: String::new(),
             refresh: None,
+            path_template: String::new(),
         }],
         endpoints: vec![sandbox_v1::NetworkEndpoint {
             host: upstream_host.to_string(),

--- a/devenv.nix
+++ b/devenv.nix
@@ -7,7 +7,12 @@
     ripgrep          # SBOX-04: CC sandbox rg check; must be in agent launch PATH
     grpcurl
     protobuf
-    ffmpeg
+    # CLI-only ffmpeg for STT audio decode. right-stt only shells out to the
+    # `ffmpeg` binary to decode audio (crates/right-stt/src/lib.rs), so the
+    # GUI/X11/SDL/pango deps in the full `ffmpeg` are dead weight. Headless
+    # drops the closure from ~1.0 GiB / 307 paths to ~299 MiB / 115 paths,
+    # ~700 MiB less to download on every fresh CI runner.
+    ffmpeg-headless
     pkg-config
     openssl
     cmake            # required by whisper-rs-sys build script


### PR DESCRIPTION
## Summary

Two related changes that together resolve the master-CI breakage caused by #110 and prevent it from happening again.

- **`fix(openshell)`** — add the new `path_template` field to the explicit `ProviderProfileCredential` struct literal in `managed_profiles.rs`. Proto v0.0.58 added field 9; the explicit literal here was the one site not using `..Default::default()`, so it broke compilation. The `cargo check` step in the proto-compat workflow already reported FAILED for #110, but the PR was merged anyway (see ci change below).
- **`ci(openshell-proto-compat)`** — two-layer defense against the same pattern recurring:
  1. Add a final `Fail workflow if cargo check failed` step. The workflow run now goes RED in the Actions tab when the bundled `cargo check` fails, instead of staying green with only a FAILED note buried in the PR body.
  2. Pass `token: \${{ secrets.BOT_PR_TOKEN || github.token }}` to `peter-evans/create-pull-request`. When `BOT_PR_TOKEN` (a fine-grained PAT) is configured as a repo secret, the PR is authored by a real account and the Tests workflow triggers normally on it. Falls back to `GITHUB_TOKEN` otherwise (= today's behavior + layer 1).

## Why #110 slipped through

- Bot PR authored via `GITHUB_TOKEN` → GitHub deliberately suppresses downstream workflow runs (loop prevention) → Tests never ran on the PR.
- `cargo check` step had `continue-on-error: true` → workflow run was green → no visual red signal anywhere.
- The `FAILED` in the PR body table was the only signal, and it was missed.

## Test plan

- [x] `cargo check -p right-openshell` passes locally
- [ ] After merge: master Tests workflow goes green
- [ ] (Optional follow-up) Create fine-grained PAT and add as `BOT_PR_TOKEN` secret so the next proto-bump PR gets full Tests on it