### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,77 @@
 # Changelog
+## [0.4.0] - 2026-06-13
+
+
+### Bug Fixes
+
+- **mcp**: Reconnect dead upstream session on first health probe
+- **bot**: Check missing STT model before decode
+- **bot**: Supervisor self-heals drifted generic provider profiles
+- **delivery**: Deliver cron attachments, stop duplicate posts on retry
+- **attachments**: Render markdown in single captions with plain fallback
+- **attachments**: Render markdown in media-group captions with plain retry
+- **progress**: Render markdown in send_progress with plain fallback
+- **telegram**: Gate markdown plain-retry to formatting errors to avoid duplicate sends
+- **cc**: Drop removed-upstream TeamCreate/TeamDelete from baseline deny-list
+- **providers**: Reject stale extra generic endpoints
+- **clippy**: Satisfy latest-stable clippy lints
+- **providers**: Dashboard config-update swaps profile via detach-dance
+- **providers**: Route config-update rollback through detach-dance restore
+- **providers**: Resolve heal sandbox name + reattach on mid-loop detach failure
+- **bot,right**: Disallow send_message on non-foreground turns + validation tests
+
+### Documentation
+
+- **learning**: Fix doc-comment placement in learning_pipeline
+- **prompt**: Teach send_message + sync aggregator instructions
+
+### Features
+
+- **openshell**: Usage hint names env var and tells agent to write the auth header
+- **learning**: Allow self-judgment skill authoring in right-learn-skill
+- **cron**: Teach what-not-how cron prompt authoring
+- **right-mcp**: Add send_message wire DTOs + client method
+- **right-db**: Add thread_focus table (v43 migration)
+- **right-db**: Thread_focus get/set module
+- **lifecycle**: Auto-manage foreground and cron learned skills
+- **attachments**: Caption_to_html/plain markdown helpers
+- **learning**: Skip async probe when a skill was authored this turn
+- **cron**: Allow inline skill authoring in cron turns
+- **bot**: Carry sandbox download context on ProgressTarget
+- **bot**: /message/send route delivering text + sandbox attachments
+- **bot**: Structured-output schema-rejection stream detector
+- **bot**: StructuredOutputLoop failure kind + reflection wording
+- **bot**: Abort + reflect on 3 consecutive structured-output rejections
+- **tunnel**: Support external reverse-proxy provider ([#119](https://github.com/onsails/right-agent/pull/119))
+- **agent-init**: Accept telegram token + chat ids non-interactively ([#117](https://github.com/onsails/right-agent/pull/117))
+- **agent-providers**: Non-interactive `right agent providers add` CLI ([#116](https://github.com/onsails/right-agent/pull/116))
+- **internal-api**: Multi-host generic providers, all-host composition, drop header_name
+- **cli**: Providers add multi --upstream-host, deprecate --header-name
+- **providers**: Merge generic provider env-var ux
+- **up**: Self-heal drifted managed provider profiles on right up
+- **learning**: Add learning-capable Cron invocation kind
+- **right**: SendMessageParams + per-turn send_message cap in ProgressRegistry
+- **right**: Call_send_message tool handler + registration + dispatch
+
+### Miscellaneous
+
+- Address final review (drop dead PRAGMA in v44, document cron overview fold)
+
+### Refactor
+
+- **right-db**: [**breaking**] Remove legacy rusqlite FTS5 scrubber after v34 soak
+- **cc**: Learning-preserving disallowed-tools helper for cron
+- **bot**: Adapt provider callers to multi-host GenericProvider
+- **providers**: Simplify generic policy strip on remove
+- **bot,right**: Single-parse schema-rejection detector + outbox prefix const
+
+### Testing
+
+- **mcp,memory**: Install rustls crypto provider per-test for nextest isolation
+- **learning**: Update curator candidate test for foreground+cron auto-management
+- **bot**: Message_send route auth/lookup coverage
+- **providers**: Pin config-update ordering on update_referenced_profile
+
 ## [0.3.4] - 2026-06-10
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,76 +1,35 @@
 # Changelog
 ## [0.4.0] - 2026-06-13
 
+### Learning & Skills
 
-### Bug Fixes
+- Agents now author and patch `rightx-*` skills mid-turn on their own judgment — not only when the user explicitly asks. Cron sessions can also write skills inline during a run; the async post-turn probe skips any turn where the agent already wrote one.
+- Agent-authored and cron-authored skills now participate in the curator's auto-lifecycle (active → stale → archived when unused). Use the dashboard pin to keep a skill permanently.
+- The cron prompt guide now teaches "what, not how": put the goal in the cron `prompt:` and push the repeatable procedure into a `rightx-*` skill the cron loads at run time.
+- Skill-learning receipts appear in the conversation language instead of always in English.
 
-- **mcp**: Reconnect dead upstream session on first health probe
-- **bot**: Check missing STT model before decode
-- **bot**: Supervisor self-heals drifted generic provider profiles
-- **delivery**: Deliver cron attachments, stop duplicate posts on retry
-- **attachments**: Render markdown in single captions with plain fallback
-- **attachments**: Render markdown in media-group captions with plain retry
-- **progress**: Render markdown in send_progress with plain fallback
-- **telegram**: Gate markdown plain-retry to formatting errors to avoid duplicate sends
-- **cc**: Drop removed-upstream TeamCreate/TeamDelete from baseline deny-list
-- **providers**: Reject stale extra generic endpoints
-- **clippy**: Satisfy latest-stable clippy lints
-- **providers**: Dashboard config-update swaps profile via detach-dance
-- **providers**: Route config-update rollback through detach-dance restore
-- **providers**: Resolve heal sandbox name + reattach on mid-loop detach failure
-- **bot,right**: Disallow send_message on non-foreground turns + validation tests
+### Agents & Conversations
 
-### Documentation
+- New `/set_focus` Telegram command opens a Mini App where operators set standing instructions for any DM, group, or forum topic. Those instructions appear in the agent's system prompt every turn in that scope. Agents update their own per-thread notes via the new `mcp__right__thread_focus_set` tool.
+- New `mcp__right__send_message` MCP tool lets agents send standalone Telegram messages — text, photos, documents, or media groups — at any point during a turn, instead of cramming all output into the single terminal reply.
+- A foreground turn that submits malformed StructuredOutput three times consecutively now aborts and routes to reflection, producing a readable error summary instead of looping invisibly until a bot restart.
+- Attachment captions and `send_progress` messages now render Markdown (bold, italic, links, lists) instead of showing raw `**asterisks**`. Both fall back to plain text on Telegram parse errors.
+- Cron deliveries now send file attachments correctly and no longer post duplicate messages when a delivery is retried.
+- Dead MCP upstream sessions reconnect on the first health probe instead of staying broken until the bot restarts.
 
-- **learning**: Fix doc-comment placement in learning_pipeline
-- **prompt**: Teach send_message + sync aggregator instructions
+### Providers & Sandbox
 
-### Features
+- Generic providers now support multiple upstream hosts per entry. The dashboard removes the confusing "Header name" field — agents write the auth header themselves using the named env var, exactly as the API docs describe.
+- fal.ai is now a built-in one-click provider type. Paste the API key and `right` provisions all required hosts automatically.
+- Provider profiles self-heal: `right up`, the sandbox supervisor, and the dashboard config-update all update a drifted profile via a detach/delete/reimport/reattach sequence. `right up` no longer aborts with "custom provider profile already exists" after a config change.
+- Per-agent env vars declared in `agent.yaml::env` are now actually injected into the sandbox. Previously this field was documented but not implemented — `ANTHROPIC_BASE_URL` and other operator-set knobs had no effect.
 
-- **openshell**: Usage hint names env var and tells agent to write the auth header
-- **learning**: Allow self-judgment skill authoring in right-learn-skill
-- **cron**: Teach what-not-how cron prompt authoring
-- **right-mcp**: Add send_message wire DTOs + client method
-- **right-db**: Add thread_focus table (v43 migration)
-- **right-db**: Thread_focus get/set module
-- **lifecycle**: Auto-manage foreground and cron learned skills
-- **attachments**: Caption_to_html/plain markdown helpers
-- **learning**: Skip async probe when a skill was authored this turn
-- **cron**: Allow inline skill authoring in cron turns
-- **bot**: Carry sandbox download context on ProgressTarget
-- **bot**: /message/send route delivering text + sandbox attachments
-- **bot**: Structured-output schema-rejection stream detector
-- **bot**: StructuredOutputLoop failure kind + reflection wording
-- **bot**: Abort + reflect on 3 consecutive structured-output rejections
-- **tunnel**: Support external reverse-proxy provider ([#119](https://github.com/onsails/right-agent/pull/119))
-- **agent-init**: Accept telegram token + chat ids non-interactively ([#117](https://github.com/onsails/right-agent/pull/117))
-- **agent-providers**: Non-interactive `right agent providers add` CLI ([#116](https://github.com/onsails/right-agent/pull/116))
-- **internal-api**: Multi-host generic providers, all-host composition, drop header_name
-- **cli**: Providers add multi --upstream-host, deprecate --header-name
-- **providers**: Merge generic provider env-var ux
-- **up**: Self-heal drifted managed provider profiles on right up
-- **learning**: Add learning-capable Cron invocation kind
-- **right**: SendMessageParams + per-turn send_message cap in ProgressRegistry
-- **right**: Call_send_message tool handler + registration + dispatch
+### Platform
 
-### Miscellaneous
-
-- Address final review (drop dead PRAGMA in v44, document cron overview fold)
-
-### Refactor
-
-- **right-db**: [**breaking**] Remove legacy rusqlite FTS5 scrubber after v34 soak
-- **cc**: Learning-preserving disallowed-tools helper for cron
-- **bot**: Adapt provider callers to multi-host GenericProvider
-- **providers**: Simplify generic policy strip on remove
-- **bot,right**: Single-parse schema-rejection detector + outbox prefix const
-
-### Testing
-
-- **mcp,memory**: Install rustls crypto provider per-test for nextest isolation
-- **learning**: Update curator candidate test for foreground+cron auto-management
-- **bot**: Message_send route auth/lookup coverage
-- **providers**: Pin config-update ordering on update_referenced_profile
+- Operators with their own reverse proxy (Caddy, nginx, Traefik) can set `tunnel.provider: external` in `~/.right/config.yaml`. `right up` then skips the cloudflared binary check, credentials file, and process. Existing configs without the field default to cloudflared.
+- `right agent init` now accepts `--telegram-token` and `--telegram-allowed-chat-ids` flags (and reads `RIGHT_TELEGRAM_TOKEN` from the environment) for fully non-interactive agent creation without entering the wizard.
+- New `right agent providers add <agent> --type <type> --label <label>` CLI command attaches providers without the Telegram dashboard. The credential is read from `RIGHT_PROVIDER_CREDENTIAL` to avoid leaking secrets to shell history and process tables.
+- **Breaking:** Databases that were never migrated past schema v34 (pre-v0.3.x era) can no longer be opened. Agents deployed on v0.3.x are unaffected.
 
 ## [0.3.4] - 2026-06-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3644,7 +3644,7 @@ dependencies = [
 
 [[package]]
 name = "right"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "right-agent"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "const_format",
@@ -3735,7 +3735,7 @@ dependencies = [
 
 [[package]]
 name = "right-agent-config"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "miette",
  "serde",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "right-bot"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3807,7 +3807,7 @@ dependencies = [
 
 [[package]]
 name = "right-codegen"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "dirs",
  "include_dir",
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "right-config"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "dirs",
  "miette",
@@ -3847,7 +3847,7 @@ dependencies = [
 
 [[package]]
 name = "right-dashboard"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -3871,7 +3871,7 @@ dependencies = [
 
 [[package]]
 name = "right-db"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "fs4 1.1.0",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "right-hostpath"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "tempfile",
  "thiserror 2.0.18",
@@ -3893,7 +3893,7 @@ dependencies = [
 
 [[package]]
 name = "right-lifecycle"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "right-db",
@@ -3906,7 +3906,7 @@ dependencies = [
 
 [[package]]
 name = "right-mcp"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "axum",
  "base64",
@@ -3940,7 +3940,7 @@ dependencies = [
 
 [[package]]
 name = "right-memory"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "fastrand",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "right-openshell"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -3988,11 +3988,11 @@ dependencies = [
 
 [[package]]
 name = "right-platform-knobs"
-version = "0.3.4"
+version = "0.4.0"
 
 [[package]]
 name = "right-platform-store"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "futures",
  "miette",
@@ -4005,7 +4005,7 @@ dependencies = [
 
 [[package]]
 name = "right-process"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "nix",
  "tempfile",
@@ -4015,14 +4015,14 @@ dependencies = [
 
 [[package]]
 name = "right-prompt-safety"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "ironclaw_safety",
 ]
 
 [[package]]
 name = "right-runtime-state"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "base64",
  "miette",
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "right-stt"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "futures",
  "reqwest 0.13.4",
@@ -4048,7 +4048,7 @@ dependencies = [
 
 [[package]]
 name = "right-ui"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "inquire",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.4"
+version = "0.4.0"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION



## 🤖 New release

* `right-agent`: 0.3.4 -> 0.4.0
* `right-bot`: 0.3.4 -> 0.4.0
* `right`: 0.3.4 -> 0.4.0
* `right-agent-config`: 0.3.4 -> 0.4.0
* `right-config`: 0.3.4 -> 0.4.0
* `right-db`: 0.3.4 -> 0.4.0
* `right-mcp`: 0.3.4 -> 0.4.0
* `right-process`: 0.3.4 -> 0.4.0
* `right-openshell`: 0.3.4 -> 0.4.0
* `right-platform-knobs`: 0.3.4 -> 0.4.0
* `right-runtime-state`: 0.3.4 -> 0.4.0
* `right-codegen`: 0.3.4 -> 0.4.0
* `right-prompt-safety`: 0.3.4 -> 0.4.0
* `right-memory`: 0.3.4 -> 0.4.0
* `right-stt`: 0.3.4 -> 0.4.0
* `right-ui`: 0.3.4 -> 0.4.0
* `right-lifecycle`: 0.3.4 -> 0.4.0
* `right-dashboard`: 0.3.4 -> 0.4.0
* `right-platform-store`: 0.3.4 -> 0.4.0
* `right-hostpath`: 0.3.4 -> 0.4.0

<details><summary><i><b>Changelog</b></i></summary><p>



## `right`

<blockquote>

## [0.4.0] - 2026-06-13

### Learning & Skills

- Agents now author and patch `rightx-*` skills mid-turn on their own judgment — not only when the user explicitly asks. Cron sessions can also write skills inline during a run; the async post-turn probe skips any turn where the agent already wrote one.
- Agent-authored and cron-authored skills now participate in the curator's auto-lifecycle (active → stale → archived when unused). Use the dashboard pin to keep a skill permanently.
- The cron prompt guide now teaches "what, not how": put the goal in the cron `prompt:` and push the repeatable procedure into a `rightx-*` skill the cron loads at run time.
- Skill-learning receipts appear in the conversation language instead of always in English.

### Agents & Conversations

- New `/set_focus` Telegram command opens a Mini App where operators set standing instructions for any DM, group, or forum topic. Those instructions appear in the agent's system prompt every turn in that scope. Agents update their own per-thread notes via the new `mcp__right__thread_focus_set` tool.
- New `mcp__right__send_message` MCP tool lets agents send standalone Telegram messages — text, photos, documents, or media groups — at any point during a turn, instead of cramming all output into the single terminal reply.
- A foreground turn that submits malformed StructuredOutput three times consecutively now aborts and routes to reflection, producing a readable error summary instead of looping invisibly until a bot restart.
- Attachment captions and `send_progress` messages now render Markdown (bold, italic, links, lists) instead of showing raw `**asterisks**`. Both fall back to plain text on Telegram parse errors.
- Cron deliveries now send file attachments correctly and no longer post duplicate messages when a delivery is retried.
- Dead MCP upstream sessions reconnect on the first health probe instead of staying broken until the bot restarts.

### Providers & Sandbox

- Generic providers now support multiple upstream hosts per entry. The dashboard removes the confusing "Header name" field — agents write the auth header themselves using the named env var, exactly as the API docs describe.
- fal.ai is now a built-in one-click provider type. Paste the API key and `right` provisions all required hosts automatically.
- Provider profiles self-heal: `right up`, the sandbox supervisor, and the dashboard config-update all update a drifted profile via a detach/delete/reimport/reattach sequence. `right up` no longer aborts with "custom provider profile already exists" after a config change.
- Per-agent env vars declared in `agent.yaml::env` are now actually injected into the sandbox. Previously this field was documented but not implemented — `ANTHROPIC_BASE_URL` and other operator-set knobs had no effect.

### Platform

- Operators with their own reverse proxy (Caddy, nginx, Traefik) can set `tunnel.provider: external` in `~/.right/config.yaml`. `right up` then skips the cloudflared binary check, credentials file, and process. Existing configs without the field default to cloudflared.
- `right agent init` now accepts `--telegram-token` and `--telegram-allowed-chat-ids` flags (and reads `RIGHT_TELEGRAM_TOKEN` from the environment) for fully non-interactive agent creation without entering the wizard.
- New `right agent providers add <agent> --type <type> --label <label>` CLI command attaches providers without the Telegram dashboard. The credential is read from `RIGHT_PROVIDER_CREDENTIAL` to avoid leaking secrets to shell history and process tables.
- **Breaking:** Databases that were never migrated past schema v34 (pre-v0.3.x era) can no longer be opened. Agents deployed on v0.3.x are unaffected.
</blockquote>



















</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).
