### PR TITLE
feat(agent-providers): non-interactive `right agent providers add` CLI

### DIFF
--- a/crates/right/src/main.rs
+++ b/crates/right/src/main.rs
@@ -4626,15 +4626,9 @@ async fn cmd_agent_providers_add(
     header_name: Option<&str>,
     env_var: Option<&str>,
 ) -> miette::Result<()> {
-    let socket_path = home.join("run/internal.sock");
-    if !socket_path.exists() {
-        return Err(miette::miette!(
-            help = "Start right first with `right up`",
-            "Internal API socket not found at {} — `right up` must be running",
-            socket_path.display()
-        ));
-    }
-
+    // Validate the static argument shape before probing runtime state, so a
+    // misconfigured command surfaces the actionable arg error even when
+    // `right up` isn't running yet.
     let generic = if type_ == "generic" {
         let host = upstream_host
             .ok_or_else(|| miette::miette!("--upstream-host is required for `--type generic`"))?;
@@ -4649,6 +4643,15 @@ async fn cmd_agent_providers_add(
     } else {
         None
     };
+
+    let socket_path = home.join("run/internal.sock");
+    if !socket_path.exists() {
+        return Err(miette::miette!(
+            help = "Start right first with `right up`",
+            "Internal API socket not found at {} — `right up` must be running",
+            socket_path.display()
+        ));
+    }
 
     let req = right_mcp::internal_client::ProviderCreateRequest {
         agent,
@@ -4665,7 +4668,7 @@ async fn cmd_agent_providers_add(
         .map_err(|e| miette::miette!("provider_create failed: {e:#}"))?;
     println!(
         "{}",
-        serde_json::to_string_pretty(&view).unwrap_or_default()
+        serde_json::to_string_pretty(&view).map_err(|e| miette::miette!("{e:#}"))?
     );
     Ok(())
 }

--- a/crates/right/src/main.rs
+++ b/crates/right/src/main.rs
@@ -413,6 +413,15 @@ pub enum AgentCommands {
         #[command(subcommand)]
         command: AgentSkillCommands,
     },
+    /// Programmatic provider management (mirrors the Telegram Mini App
+    /// dashboard's create/list flows). Intended for fleet automation
+    /// where the dashboard isn't reachable (e.g. multi-tenant
+    /// provisioning by an upstream registrar). Requires `right up` to
+    /// be running so the internal API socket exists.
+    Providers {
+        #[command(subcommand)]
+        command: AgentProvidersCommands,
+    },
 }
 
 /// Skill lifecycle subcommands.
@@ -420,6 +429,52 @@ pub enum AgentCommands {
 pub enum AgentSkillCommands {
     /// List learned skill lifecycle rows across agents
     List,
+}
+
+/// Provider management subcommands. Same surface the dashboard exposes
+/// via internal-socket REST; this is a non-interactive entry point for
+/// automation. All actions go through the internal API so existing
+/// validation, locking, and gateway-side rollback are reused.
+#[derive(Subcommand)]
+pub enum AgentProvidersCommands {
+    /// Add a provider to an agent. Generic providers route to an
+    /// authored OpenShell profile (host + header + env-var). Built-in
+    /// providers (e.g. `anthropic`, `github`) reuse OpenShell's
+    /// catalog profile. The credential value is taken from
+    /// `RIGHT_PROVIDER_CREDENTIAL` env if not given via
+    /// `--credential` — passing secrets on argv leaks them to
+    /// `ps`, shell history, and journald.
+    Add {
+        /// Agent name
+        agent: String,
+        /// Provider type slug. `generic` requires `--upstream-host`
+        /// and `--env-var`; built-in types (e.g. `anthropic`,
+        /// `github`) pull these from OpenShell's profile catalog.
+        #[arg(long, default_value = "generic")]
+        type_: String,
+        /// Optional label, used in the resulting provider name
+        /// (`<agent>-<label>`). Defaults to the type slug.
+        #[arg(long)]
+        label: Option<String>,
+        /// Credential value (the API token / key). Prefer
+        /// `RIGHT_PROVIDER_CREDENTIAL` env to avoid argv leak.
+        #[arg(long, env = "RIGHT_PROVIDER_CREDENTIAL", hide_env_values = true)]
+        credential: String,
+        /// Upstream host (e.g. `api.openai.com`). Generic only.
+        #[arg(long)]
+        upstream_host: Option<String>,
+        /// Upstream path prefix (e.g. `/v1`). Generic only.
+        #[arg(long)]
+        upstream_path_prefix: Option<String>,
+        /// Header name to substitute into. Default `Authorization`.
+        /// Generic only.
+        #[arg(long)]
+        header_name: Option<String>,
+        /// Env var name the sandbox sees as the placeholder.
+        /// Generic only.
+        #[arg(long)]
+        env_var: Option<String>,
+    },
 }
 
 /// Subcommands for `right memory`.
@@ -1130,6 +1185,7 @@ async fn main() -> miette::Result<()> {
                 Ok(())
             }
             AgentCommands::Skill { command } => cmd_agent_skill(&home, command).await,
+            AgentCommands::Providers { command } => cmd_agent_providers(&home, command).await,
         },
         Commands::Memory { command } => match command {
             MemoryCommands::List {
@@ -4529,6 +4585,89 @@ async fn cmd_agent_skill(home: &Path, command: AgentSkillCommands) -> miette::Re
     match command {
         AgentSkillCommands::List => cmd_agent_skill_list(home).await,
     }
+}
+
+async fn cmd_agent_providers(home: &Path, command: AgentProvidersCommands) -> miette::Result<()> {
+    match command {
+        AgentProvidersCommands::Add {
+            agent,
+            type_,
+            label,
+            credential,
+            upstream_host,
+            upstream_path_prefix,
+            header_name,
+            env_var,
+        } => {
+            cmd_agent_providers_add(
+                home,
+                &agent,
+                &type_,
+                label.as_deref(),
+                &credential,
+                upstream_host.as_deref(),
+                upstream_path_prefix.as_deref(),
+                header_name.as_deref(),
+                env_var.as_deref(),
+            )
+            .await
+        }
+    }
+}
+
+async fn cmd_agent_providers_add(
+    home: &Path,
+    agent: &str,
+    type_: &str,
+    label: Option<&str>,
+    credential: &str,
+    upstream_host: Option<&str>,
+    upstream_path_prefix: Option<&str>,
+    header_name: Option<&str>,
+    env_var: Option<&str>,
+) -> miette::Result<()> {
+    let socket_path = home.join("run/internal.sock");
+    if !socket_path.exists() {
+        return Err(miette::miette!(
+            help = "Start right first with `right up`",
+            "Internal API socket not found at {} — `right up` must be running",
+            socket_path.display()
+        ));
+    }
+
+    let generic = if type_ == "generic" {
+        let host = upstream_host
+            .ok_or_else(|| miette::miette!("--upstream-host is required for `--type generic`"))?;
+        let env =
+            env_var.ok_or_else(|| miette::miette!("--env-var is required for `--type generic`"))?;
+        Some(right_mcp::internal_client::ProviderCreateGenericArg {
+            env_var: env,
+            header_name,
+            upstream_host: host,
+            upstream_path_prefix,
+        })
+    } else {
+        None
+    };
+
+    let req = right_mcp::internal_client::ProviderCreateRequest {
+        agent,
+        type_,
+        label,
+        credential,
+        generic,
+    };
+
+    let client = right_mcp::internal_client::InternalClient::new(&socket_path);
+    let view = client
+        .provider_create(&req)
+        .await
+        .map_err(|e| miette::miette!("provider_create failed: {e:#}"))?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&view).unwrap_or_default()
+    );
+    Ok(())
 }
 
 async fn cmd_agent_skill_list(home: &Path) -> miette::Result<()> {


### PR DESCRIPTION
Provider management has been dashboard-only since v0.3.0 — agents, fleet operators, and automation tools that drive `right` programmatically have no way to attach a provider without going through the Telegram Mini App. The new subcommand fills that gap by exposing the same internal-socket REST API the dashboard uses, with the validation, locking, and gateway-side rollback that path already provides:

    RIGHT_PROVIDER_CREDENTIAL=<token> \
      right agent providers add my-agent \
        --type generic \
        --label litellm \
        --upstream-host litellm.example.com \
        --header-name x-api-key \
        --env-var ANTHROPIC_API_KEY

Built-in profiles work the same way without the generic-only flags:

    RIGHT_PROVIDER_CREDENTIAL=<token> \
      right agent providers add my-agent \
        --type github --label gh

The credential value is taken from the `RIGHT_PROVIDER_CREDENTIAL` environment variable rather than `--credential` value-flag when both are absent on argv — passing secrets via argv leaks them to `ps`, shell history, and journald, the same anti-pattern this codebase already avoids for telegram tokens (see `right init --telegram-token`, which also accepts `RIGHT_TELEGRAM_TOKEN`). `hide_env_values = true` keeps the env var out of `--help` output.

Requires `right up` to be running (the subcommand talks to `~/.right/run/internal.sock`) and emits a clear error pointing at `right up` when the socket is absent. Output is the same `ProviderView` JSON the dashboard sees, so callers can pipe to `jq`.

This is intended for fleet automation where the dashboard is not the control plane (e.g. a multi-tenant registrar provisioning agents on a shared host). Dashboard-driven workflows are unchanged.