### PR TITLE
ci(claude-review): pass github_token to fix 401 Invalid OIDC token

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,11 +30,13 @@ jobs:
       github.event.sender.login != 'claude[bot]'
 
     runs-on: ubuntu-latest
+    # write on pull-requests/issues so the action can post the review with
+    # the workflow GITHUB_TOKEN (see github_token below). No id-token needed:
+    # passing github_token skips the OIDC app-token exchange entirely.
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
+      pull-requests: write
+      issues: write
 
     steps:
       - name: Checkout repository
@@ -51,6 +53,14 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Provide an explicit token so the action skips its OIDC ->
+          # GitHub-App token exchange. That exchange 401s ("Invalid OIDC
+          # token") under pull_request_target — the OIDC subject differs
+          # from the pull_request event the exchange expects. Under
+          # pull_request_target the workflow GITHUB_TOKEN runs in base
+          # context with full write, so it can post the review (incl. on
+          # fork PRs). setupGitHubToken() short-circuits on this input.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Problem

Every `claude-review` run since the switch to `pull_request_target` fails at:

```
Exchanging OIDC token for app token...
App token exchange failed: 401 Unauthorized - Invalid OIDC token
```

The 14 historical **successes were all `event: pull_request`**; every `pull_request_target` run fails. The action's OIDC → GitHub-App token exchange rejects the `pull_request_target` OIDC subject (different `sub`/`event_name` than the `pull_request` event it expects). This is independent of the label-gate change in #121 — the trigger fires correctly; the token exchange is what 401s.

## Fix

`setupGitHubToken()` in claude-code-action returns early when `github_token` (env `OVERRIDE_GITHUB_TOKEN`) is set, **skipping the OIDC request and `exchangeForAppToken()`** ([token.ts](https://github.com/anthropics/claude-code-action/blob/main/src/github/token.ts)).

- Pass `github_token: ${{ secrets.GITHUB_TOKEN }}`. Under `pull_request_target` this token runs in **base context with full permissions**, so it can post the review even on fork PRs.
- Bump `pull-requests`/`issues` to `write` (the action now posts with GITHUB_TOKEN instead of the Claude App token).
- Drop `id-token: write` — no longer used once the OIDC exchange is skipped.

Reviews will be posted by `github-actions[bot]` instead of the Claude GitHub App.

## Test plan

After merge, add the `claude-review` label to an open PR (e.g. #119) and confirm the run reaches Claude and posts a review instead of 401-ing.