### PR TITLE
chore(openshell): re-vendor proto to v0.0.62

### DIFF
--- a/crates/right-openshell/proto/UPSTREAM.md
+++ b/crates/right-openshell/proto/UPSTREAM.md
@@ -1,3 +1,3 @@
-tag: v0.0.58
-fetched: 2026-06-09T06:56:23Z
+tag: v0.0.62
+fetched: 2026-06-13T07:00:33Z
 upstream: https://github.com/NVIDIA/OpenShell

--- a/crates/right-openshell/proto/openshell/openshell.proto
+++ b/crates/right-openshell/proto/openshell/openshell.proto
@@ -319,10 +319,8 @@ message SandboxSpec {
   repeated string providers = 8;
   // Request NVIDIA GPU resources for this sandbox.
   bool gpu = 9;
-  // Optional PCI BDF address (e.g. "0000:2d:00.0") or device index
-  // (e.g. "0", "1"). When empty with gpu=true, the driver assigns the
-  // first available GPU.
-  string gpu_device = 10;
+  reserved 10;
+  reserved "gpu_device";
   // Field 11 was `proposal_approval_mode`. The approval mode is now a
   // runtime setting (gateway or sandbox scope) read via UpdateConfig /
   // GetSandboxConfig, so it can be flipped on a running sandbox and
@@ -892,6 +890,52 @@ message ProviderProfileDiagnostic {
   string severity = 5;
 }
 
+// Endpoint selector for token grant audience overrides.
+message ProviderCredentialTokenGrantAudienceOverride {
+  // Optional: endpoint host selector. If omitted, inherits the profile endpoint host.
+  string host = 1;
+
+  // Optional: endpoint port selector. If omitted, matches the expanded profile endpoint port.
+  uint32 port = 2;
+
+  // Optional: endpoint path selector. If omitted, inherits the profile endpoint path.
+  string path = 3;
+
+  // Resource audience to request for matching endpoints.
+  string audience = 4;
+
+  // Optional: OAuth2 scopes to request. If omitted, inherits the token grant scopes.
+  repeated string scopes = 5;
+}
+
+// Provider credential token grant configuration.
+// When present, the credential is obtained dynamically via OAuth2 grant when needed.
+message ProviderCredentialTokenGrant {
+  // OAuth2 token endpoint URL (e.g., https://keycloak.example.com/realms/my-realm/protocol/openid-connect/token)
+  string token_endpoint = 1;
+
+  // Optional: default resource audience to request from the token service
+  string audience = 2;
+
+  // Optional: audience to request when fetching the JWT-SVID from SPIRE.
+  // If omitted, the sandbox derives this from token_endpoint.
+  string jwt_svid_audience = 6;
+
+  // Optional: OAuth2 scopes to request
+  repeated string scopes = 3;
+
+  // Optional: override token cache TTL (seconds)
+  // If 0 or omitted, use expires_in from token response
+  int64 cache_ttl_seconds = 4;
+
+  // Optional: endpoint-specific resource audience overrides.
+  repeated ProviderCredentialTokenGrantAudienceOverride audience_overrides = 5;
+
+  // Optional: OAuth2 client_assertion_type value. If omitted, OpenShell uses
+  // urn:ietf:params:oauth:client-assertion-type:jwt-bearer.
+  string client_assertion_type = 7;
+}
+
 // Provider credential declaration.
 message ProviderProfileCredential {
   string name = 1;
@@ -903,6 +947,7 @@ message ProviderProfileCredential {
   string query_param = 7;
   ProviderCredentialRefresh refresh = 8;
   string path_template = 9;
+  ProviderCredentialTokenGrant token_grant = 10;
 }
 
 enum ProviderCredentialRefreshStrategy {
@@ -1100,6 +1145,10 @@ message GetSandboxProviderEnvironmentResponse {
   uint64 provider_env_revision = 2;
   // Expiration timestamps for returned environment variables.
   map<string, int64> credential_expires_at_ms = 3;
+  // Dynamic credentials that require token grants or other runtime injection.
+  // Maps endpoint-bound provider metadata to credential metadata.
+  // Supervisor uses this to inject Authorization headers for token grant credentials.
+  map<string, ProviderProfileCredential> dynamic_credentials = 4;
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/right-openshell/src/managed_profiles.rs
+++ b/crates/right-openshell/src/managed_profiles.rs
@@ -146,6 +146,7 @@ pub fn fal_profile() -> proto_v1::ProviderProfile {
             query_param: String::new(),
             refresh: None,
             path_template: String::new(),
+            token_grant: None,
         }],
         endpoints: hosts
             .iter()
@@ -192,6 +193,7 @@ pub fn author_generic_profile(
             query_param: String::new(),
             refresh: None,
             path_template: String::new(),
+            token_grant: None,
         }],
         endpoints: upstream_hosts
             .iter()

--- a/crates/right-openshell/src/providers_tests.rs
+++ b/crates/right-openshell/src/providers_tests.rs
@@ -759,6 +759,7 @@ async fn get_sandbox_provider_environment_returns_map() {
                 environment: env,
                 provider_env_revision: 1,
                 credential_expires_at_ms: HashMap::new(),
+                dynamic_credentials: HashMap::new(),
             })
         })),
         ..Default::default()


### PR DESCRIPTION
Automated re-vendor of the OpenShell protos to **v0.0.62**.

| static check | result |
|---|---|
| `buf breaking` (PACKAGE) | BREAKING |
| `cargo check -p right-openshell` | FAILED |

<details><summary>buf breaking output</summary>

```
crates/right-openshell/proto/openshell/openshell.proto:309:1:Previously present field "10" with name "gpu_device" on message "SandboxSpec" was deleted.
```

</details>

<details><summary>cargo check (tail)</summary>

```
   Compiling tonic-build v0.14.6
    Checking futures-executor v0.3.32
   Compiling pin-project-internal v1.1.11
   Compiling ref-cast-impl v1.0.25
   Compiling serde_derive_internals v0.29.1
    Checking encoding_rs v0.8.35
    Checking arraydeque v0.5.1
    Checking matchit v0.8.4
    Checking const-oid v0.10.2
    Checking anstyle v1.0.14
    Checking option-ext v0.2.0
    Checking iri-string v0.7.11
    Checking annotate-snippets v0.12.13
    Checking dirs-sys v0.5.0
    Checking digest v0.11.2
    Checking axum v0.8.9
    Checking tower-http v0.6.8
    Checking granit-parser v0.0.3
    Checking encoding_rs_io v0.1.7
   Compiling schemars_derive v1.2.1
    Checking pin-project v1.1.11
    Checking futures v0.3.32
   Compiling tonic-prost-build v0.14.6
    Checking rand v0.10.1
    Checking mimalloc v0.1.52
    Checking url v2.5.8
    Checking serde_urlencoded v0.7.1
    Checking hyper-timeout v0.5.2
    Checking dyn-clone v1.0.20
    Checking nohash-hasher v0.2.0
   Compiling rmcp v1.7.0
    Checking serde-saphyr v0.0.27
    Checking turso_sdk_kit v0.7.0-pre.7
    Checking turso_sync_engine v0.7.0-pre.7
    Checking schemars v1.2.1
   Compiling right-openshell v0.3.4 (/home/runner/work/right-agent/right-agent/crates/right-openshell)
   Compiling rmcp-macros v1.7.0
    Checking dirs v6.0.0
    Checking sse-stream v0.2.3
    Checking fs4 v1.1.0
    Checking same-file v1.0.6
    Checking turso_sync_sdk_kit v0.7.0-pre.7
    Checking walkdir v2.5.0
    Checking right-process v0.3.4 (/home/runner/work/right-agent/right-agent/crates/right-process)
    Checking hmac v0.13.0
    Checking sha2 v0.11.0
    Checking which v8.0.3
   Compiling include_dir_macros v0.7.4
    Checking memo-map v0.3.3
    Checking shlex v2.0.1
    Checking minijinja v2.20.0
    Checking include_dir v0.7.4
    Checking right-config v0.3.4 (/home/runner/work/right-agent/right-agent/crates/right-config)
    Checking right-runtime-state v0.3.4 (/home/runner/work/right-agent/right-agent/crates/right-runtime-state)
    Checking right-agent-config v0.3.4 (/home/runner/work/right-agent/right-agent/crates/right-agent-config)
    Checking right-platform-knobs v0.3.4 (/home/runner/work/right-agent/right-agent/crates/right-platform-knobs)
    Checking rustls-webpki v0.103.10
    Checking tokio-rustls v0.26.4
    Checking rustls-platform-verifier v0.6.2
    Checking hyper-rustls v0.27.9
    Checking tonic v0.14.6
    Checking reqwest v0.13.4
    Checking turso v0.7.0-pre.7
    Checking right-db v0.3.4 (/home/runner/work/right-agent/right-agent/crates/right-db)
    Checking tonic-prost v0.14.6
error[E0063]: missing field `token_grant` in initializer of `ProviderProfileCredential`
   --> crates/right-openshell/src/managed_profiles.rs:139:27
    |
139 |         credentials: vec![proto_v1::ProviderProfileCredential {
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `token_grant`

error[E0063]: missing field `token_grant` in initializer of `ProviderProfileCredential`
   --> crates/right-openshell/src/managed_profiles.rs:183:27
    |
183 |         credentials: vec![proto_v1::ProviderProfileCredential {
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `token_grant`

For more information about this error, try `rustc --explain E0063`.
error: could not compile `right-openshell` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
```

</details>

---
A **BREAKING** or **FAILED** result means upstream changed the wire/API shape.
Audit `SandboxReadiness` and any code decoding moved/removed fields, then bump
`MIN_OPENSHELL_VERSION` and the CI `OPENSHELL_VERSION` pin as needed.
This bot surfaces drift only — it does not fix Rust. Full CI runs on this PR only
when `BOT_PR_TOKEN` (a fine-grained PAT) is configured as a repo secret;
otherwise bot-authored PRs don't trigger downstream workflows. Either way, the
`openshell-proto-compat` workflow run itself goes RED when `cargo check` fails,
so a failing proto bump is visible in the Actions tab even without full CI.