### PR TITLE
fix(site): live GitHub star count on the landing page (client-side, no build-time fetch)

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -20,7 +20,7 @@ const starLabel = formatStars(await getStars());
           <a class="btn" href="#install">install</a>
           <a class="starbtn" href="https://github.com/onsails/right-agent">
             <svg class="ico" viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M12 2l2.9 6.9 7.1.6-5.4 4.7 1.6 7L12 18.3 5.8 21.2l1.6-7L2 9.5l7.1-.6z"/></svg>
-            star on github{starLabel && <span class="cnt">{starLabel}</span>}
+            star on github<span class="cnt" hidden={!starLabel}>{starLabel}</span>
           </a>
           <a class="ghost" href="/docs/">read the docs <span>→</span></a>
         </div>
@@ -32,3 +32,21 @@ const starLabel = formatStars(await getStars());
     </div>
   </div>
 </header>
+
+<script>
+  // The star count is baked in at build time; refresh it live from the GitHub
+  // API on load so it stays current between site deploys.
+  import { REPO, formatStars } from '../lib/github';
+  fetch(`https://api.github.com/repos/${REPO}`, {
+    headers: { Accept: 'application/vnd.github+json' },
+  })
+    .then((r) => (r.ok ? r.json() : null))
+    .then((d) => {
+      if (!d || typeof d.stargazers_count !== 'number') return;
+      const el = document.querySelector('.starbtn .cnt');
+      if (!(el instanceof HTMLElement)) return;
+      el.textContent = formatStars(d.stargazers_count);
+      el.hidden = false;
+    })
+    .catch(() => {});
+</script>

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -1,8 +1,6 @@
 ---
 import { Image } from 'astro:assets';
 import screenshot from '../assets/screenshot.png';
-import { getStars, formatStars } from '../lib/github';
-const starLabel = formatStars(await getStars());
 ---
 <header class="hero">
   <div class="wrap">
@@ -20,7 +18,7 @@ const starLabel = formatStars(await getStars());
           <a class="btn" href="#install">install</a>
           <a class="starbtn" href="https://github.com/onsails/right-agent">
             <svg class="ico" viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M12 2l2.9 6.9 7.1.6-5.4 4.7 1.6 7L12 18.3 5.8 21.2l1.6-7L2 9.5l7.1-.6z"/></svg>
-            star on github<span class="cnt" hidden={!starLabel}>{starLabel}</span>
+            star on github<span class="cnt" hidden></span>
           </a>
           <a class="ghost" href="/docs/">read the docs <span>→</span></a>
         </div>
@@ -32,21 +30,3 @@ const starLabel = formatStars(await getStars());
     </div>
   </div>
 </header>
-
-<script>
-  // The star count is baked in at build time; refresh it live from the GitHub
-  // API on load so it stays current between site deploys.
-  import { REPO, formatStars } from '../lib/github';
-  fetch(`https://api.github.com/repos/${REPO}`, {
-    headers: { Accept: 'application/vnd.github+json' },
-  })
-    .then((r) => (r.ok ? r.json() : null))
-    .then((d) => {
-      if (!d || typeof d.stargazers_count !== 'number') return;
-      const el = document.querySelector('.starbtn .cnt');
-      if (!(el instanceof HTMLElement)) return;
-      el.textContent = formatStars(d.stargazers_count);
-      el.hidden = false;
-    })
-    .catch(() => {});
-</script>

--- a/site/src/layouts/Landing.astro
+++ b/site/src/layouts/Landing.astro
@@ -1,13 +1,11 @@
 ---
 import '../styles/landing.css';
 import PostHog from '../components/PostHog.astro';
-import { getStars, formatStars } from '../lib/github';
 interface Props { title?: string; description?: string; }
 const {
   title = 'right agent',
   description = 'an ai agent you run by messaging it. credentials stay outside the box.',
 } = Astro.props;
-const starLabel = formatStars(await getStars());
 ---
 <!doctype html>
 <html lang="en">
@@ -82,13 +80,36 @@ const starLabel = formatStars(await getStars());
           <a href="#install">install</a>
           <a class="starchip" href="https://github.com/onsails/right-agent" aria-label="Star right agent on GitHub">
             <svg class="ico" viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true"><path d="M12 2l2.9 6.9 7.1.6-5.4 4.7 1.6 7L12 18.3 5.8 21.2l1.6-7L2 9.5l7.1-.6z"/></svg>
-            <span>{starLabel ? `star · ${starLabel}` : 'star'}</span>
+            <span>star</span>
           </a>
         </div>
       </nav>
     </div>
 
     <slot />
+
+    <script>
+      // One live fetch of the GitHub star count for both badges on the page
+      // (nav chip + hero button), so they stay current between deploys with no
+      // build-time API call.
+      import { REPO, formatStars } from '../lib/github';
+      fetch(`https://api.github.com/repos/${REPO}`, {
+        headers: { Accept: 'application/vnd.github+json' },
+      })
+        .then((r) => (r.ok ? r.json() : null))
+        .then((d) => {
+          if (!d || typeof d.stargazers_count !== 'number') return;
+          const label = formatStars(d.stargazers_count);
+          const chip = document.querySelector('.starchip span');
+          if (chip instanceof HTMLElement) chip.textContent = `star · ${label}`;
+          const cnt = document.querySelector('.starbtn .cnt');
+          if (cnt instanceof HTMLElement) {
+            cnt.textContent = label;
+            cnt.hidden = false;
+          }
+        })
+        .catch(() => {});
+    </script>
 
     <script>
       const sections = Array.from(document.querySelectorAll('.section')) as HTMLElement[];

--- a/site/src/lib/github.ts
+++ b/site/src/lib/github.ts
@@ -1,7 +1,7 @@
 // Build-time GitHub star count with a graceful fallback.
 // Fetched once per build (module-level cache dedupes multiple importers).
 // If the repo is private/unreachable, returns null and the UI hides the count.
-const REPO = 'onsails/right-agent';
+export const REPO = 'onsails/right-agent';
 
 let cache: Promise<number | null> | null = null;
 

--- a/site/src/lib/github.ts
+++ b/site/src/lib/github.ts
@@ -1,21 +1,7 @@
-// Build-time GitHub star count with a graceful fallback.
-// Fetched once per build (module-level cache dedupes multiple importers).
-// If the repo is private/unreachable, returns null and the UI hides the count.
+// GitHub repo star count for the hero badge.
+// Fetched client-side (see Hero.astro) so it stays current between deploys —
+// no build-time API call, nothing to go stale.
 export const REPO = 'onsails/right-agent';
-
-let cache: Promise<number | null> | null = null;
-
-export function getStars(): Promise<number | null> {
-  if (!cache) {
-    cache = fetch(`https://api.github.com/repos/${REPO}`, {
-      headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'right-agent-site' },
-    })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((d) => (d && typeof d.stargazers_count === 'number' ? d.stargazers_count : null))
-      .catch(() => null);
-  }
-  return cache;
-}
 
 export function formatStars(n: number | null): string {
   if (n == null) return '';


### PR DESCRIPTION
## Problem

The landing page showed **26** GitHub stars while the repo was already at **30**.

Not a code bug — the count was fetched **at build time** (`getStars()` in `site/src/lib/github.ts`) and baked into the static HTML. The Pages deploy (`.github/workflows/static.yml`) only runs on `site/**` changes or manual dispatch, so the number drifted behind reality between deploys. Two badges were affected: the hero button (`.starbtn .cnt`) and the nav chip (`.starchip`).

## Fix

Fetch the count **client-side** and drop the build-time API call entirely:

- Removed `getStars()` and the module cache; `github.ts` now only exports `REPO` + `formatStars`.
- A single live fetch in the Landing layout updates **both** badges on load — the nav chip (`star · N`) and the hero button (`N`). Reuses `formatStars`; Astro tree-shakes the client bundle.
- Neutral initial markup (nav `star`, hero empty hidden span), so there's nothing to go stale and no CI GitHub request / rate-limit dependency.

Result: every visitor sees the current count, no rebuilds, no cron, no CI API call.

### Trade-off

The count now appears a fraction of a second after load (client fetch), and visitors with JS disabled / third-party requests blocked see the button without a number. Acceptable for a decorative badge, and in exchange the number can never be stale again.

## Verification

- `bun run build` — succeeds; built HTML has neutral badges, exactly one inlined GitHub fetch that updates both selectors.
- `bun run check` (astro check) — 0 errors, 0 warnings.

Merging this touches `site/**`, which triggers the Pages deploy and ships the fix.