### PR TITLE
feat(sandbox): right-sandbox production API (stage 2)

### DIFF
--- a/crates/right-sandbox/Cargo.toml
+++ b/crates/right-sandbox/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 microsandbox = "=0.6.10"
+sha2.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
@@ -15,6 +16,5 @@ anyhow.workspace = true
 rcgen.workspace = true
 rustls.workspace = true
 serde_json.workspace = true
-sha2.workspace = true
 tempfile.workspace = true
 tokio-rustls.workspace = true

--- a/crates/right-sandbox/src/egress.rs
+++ b/crates/right-sandbox/src/egress.rs
@@ -1,0 +1,181 @@
+//! Egress policy for an Agent Sandbox.
+//!
+//! The typed `Egress` value replaces the OpenShell-era `policy.yaml` codegen:
+//! the policy is a value applied through the SDK at sandbox create. Egress is
+//! create-time only — the SDK's `modify()` has no network-policy field, so
+//! changing an agent's egress mode requires a sandbox recreate.
+//!
+//! Both modes keep the `host` destination group open: the guest reaches the
+//! MCP aggregator through `host.microsandbox.internal`, and `from_profiles`
+//! already adds exactly one narrow DNS rule for the gateway resolver.
+
+use microsandbox::{NetworkPolicy, NetworkProfile};
+
+use crate::error::SandboxError;
+
+/// Egress mode for an Agent Sandbox.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum Egress {
+    /// Whole public internet plus the host group. Right's default floor.
+    #[default]
+    Permissive,
+
+    /// Deny-by-default public egress: only the host group plus an explicit
+    /// domain-suffix allowlist. Shipped but documented experimental until
+    /// exercised; the allowlist entries are domain suffixes (`"example.com"`
+    /// also covers `*.example.com`).
+    Restrictive {
+        /// Domain suffixes the guest may reach over public egress.
+        allow: Vec<String>,
+    },
+}
+
+impl Egress {
+    /// Validate the mode without constructing anything SDK-side worth
+    /// keeping. Suitable for config-load time checks.
+    pub fn validate(&self) -> Result<(), SandboxError> {
+        self.to_policy().map(|_| ())
+    }
+
+    /// Translate to the SDK's deny-by-default network policy.
+    pub(crate) fn to_policy(&self) -> Result<NetworkPolicy, SandboxError> {
+        match self {
+            Self::Permissive => Ok(NetworkPolicy::from_profiles([
+                NetworkProfile::Public,
+                NetworkProfile::Host,
+            ])),
+            Self::Restrictive { allow } => {
+                let mut policy = NetworkPolicy::from_profiles([NetworkProfile::Host]);
+                for entry in allow {
+                    policy = policy.allow_domain_suffix(entry).map_err(|err| {
+                        SandboxError::InvalidSpec {
+                            field: "egress.allow",
+                            reason: format!("invalid domain suffix {entry:?}: {err}"),
+                        }
+                    })?;
+                }
+                Ok(policy)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use microsandbox::NetworkAction;
+
+    use super::*;
+
+    /// Debug rendering of a rule's destination; the SDK's destination types
+    /// are not re-exported, so tests match on their Debug shape.
+    fn destinations(policy: &NetworkPolicy) -> Vec<String> {
+        policy
+            .rules
+            .iter()
+            .map(|rule| format!("{:?}", rule.destination))
+            .collect()
+    }
+
+    /// The DNS rule `from_profiles` adds: Host group, UDP+TCP, port 53 only.
+    fn is_dns_rule(rule: &microsandbox::NetworkRule) -> bool {
+        format!("{:?}", rule.destination) == "Group(Host)"
+            && rule
+                .ports
+                .iter()
+                .all(|range| range.start == 53 && range.end == 53)
+            && !rule.ports.is_empty()
+    }
+
+    /// The unrestricted host-group rule (no port filter).
+    fn is_host_group_rule(rule: &microsandbox::NetworkRule) -> bool {
+        format!("{:?}", rule.destination) == "Group(Host)" && rule.ports.is_empty()
+    }
+
+    #[test]
+    fn permissive_allows_public_and_host_with_dns() {
+        let policy = Egress::Permissive.to_policy().expect("permissive policy");
+
+        assert_eq!(policy.default_egress, NetworkAction::Deny);
+        assert_eq!(policy.default_ingress, NetworkAction::Allow);
+        let destinations = destinations(&policy);
+        assert_eq!(
+            destinations,
+            ["Group(Host)", "Group(Public)", "Group(Host)"],
+            "permissive = one narrow DNS rule + public + host: {destinations:?}"
+        );
+        assert!(is_dns_rule(&policy.rules[0]), "first rule is DNS: {:?}", policy.rules[0]);
+        assert!(
+            policy
+                .rules
+                .iter()
+                .all(|rule| rule.action == NetworkAction::Allow),
+            "every permissive rule is an allow rule"
+        );
+    }
+
+    #[test]
+    fn restrictive_without_allowlist_reaches_only_the_host() {
+        let policy = Egress::Restrictive { allow: Vec::new() }
+            .to_policy()
+            .expect("restrictive policy");
+
+        assert_eq!(policy.default_egress, NetworkAction::Deny);
+        assert_eq!(policy.rules.len(), 2, "DNS + host only: {:?}", policy.rules);
+        assert!(is_dns_rule(&policy.rules[0]));
+        assert!(is_host_group_rule(&policy.rules[1]));
+        assert!(
+            !destinations(&policy).iter().any(|d| d.contains("Public")),
+            "restrictive must never include the public group"
+        );
+    }
+
+    #[test]
+    fn restrictive_allowlist_prepends_domain_suffix_rules() {
+        let policy = Egress::Restrictive {
+            allow: vec!["example.com".to_owned(), "crates.io".to_owned()],
+        }
+        .to_policy()
+        .expect("allowlisted policy");
+
+        let destinations = destinations(&policy);
+        assert_eq!(
+            destinations.len(),
+            4,
+            "two allowlist rules + DNS + host: {destinations:?}"
+        );
+        // Both allowlist rules match before DNS and the host group. Their
+        // relative order carries no semantics (all are allows to distinct
+        // domains), so assert the set, not the SDK's prepend order.
+        let allowlist = &destinations[..2];
+        for domain in ["example.com", "crates.io"] {
+            assert!(
+                allowlist
+                    .iter()
+                    .any(|d| d.contains("DomainSuffix") && d.contains(domain)),
+                "missing allow rule for {domain}: {allowlist:?}"
+            );
+        }
+        assert!(is_dns_rule(&policy.rules[2]));
+        assert!(is_host_group_rule(&policy.rules[3]));
+    }
+
+    #[test]
+    fn invalid_allowlist_entries_are_rejected_with_the_entry_named() {
+        let err = Egress::Restrictive {
+            allow: vec!["ok.com".to_owned(), "not a domain!".to_owned()],
+        }
+        .validate()
+        .expect_err("an invalid suffix must fail validation");
+
+        match err {
+            SandboxError::InvalidSpec { field, reason } => {
+                assert_eq!(field, "egress.allow");
+                assert!(
+                    reason.contains("not a domain!"),
+                    "the offending entry must be named: {reason}"
+                );
+            }
+            other => panic!("expected InvalidSpec, got {other:?}"),
+        }
+    }
+}

--- a/crates/right-sandbox/src/error.rs
+++ b/crates/right-sandbox/src/error.rs
@@ -134,7 +134,7 @@ pub enum SandboxError {
     #[error("failed to install the pinned microsandbox runtime: {source}")]
     RuntimeInstall {
         #[source]
-        source: SdkError,
+        source: Box<SdkError>,
     },
     #[error("failed to lock the runtime-install lockfile {}", path.display())]
     RuntimeInstallLock { path: PathBuf, source: io::Error },
@@ -180,26 +180,33 @@ pub enum SandboxError {
         name: String,
         operation: &'static str,
         #[source]
-        source: SdkError,
+        source: Box<SdkError>,
     },
 
     /// The guest command never started (binary missing, bad cwd, guest user
     /// setup failure). A command-level error: the sandbox itself is healthy.
-    #[error("sandbox '{name}': command '{cmd}' failed to start in the guest: {message}")]
+    #[error("sandbox '{name}': command '{cmd}' failed to start in the guest ({kind}): {message}")]
     ExecSpawn {
         name: String,
         cmd: String,
+        kind: String,
         message: String,
     },
 
     /// Writing to or closing a guest command's stdin failed. The exec session
-    /// is torn down; the sandbox itself may be healthy.
+    /// is torn down; the sandbox itself may be healthy. The message carries
+    /// the full `{:#}` chain from the SDK's `ExecStdinError`.
     #[error("sandbox '{name}': stdin for '{cmd}' failed: {message}")]
     ExecStdin {
         name: String,
         cmd: String,
         message: String,
     },
+
+    /// The exec session ended without an exit event — the agent connection
+    /// dropped mid-session. A backend-health signal, not a command error.
+    #[error("sandbox '{name}': exec session for '{cmd}' ended without an exit event")]
+    ExecLost { name: String, cmd: String },
 
     /// The runtime reported the secret rotation cannot be applied through
     /// `modify()` at all (e.g. capability missing on an old runtime).
@@ -214,9 +221,10 @@ pub enum SandboxError {
         details: String,
     },
 
-    /// The plan announced changes but `apply()` reported none applied.
-    #[error("sandbox '{name}': rotating secret '{env_var}' planned changes but applied none")]
-    RotationNotApplied { name: String, env_var: String },
+    /// The sandbox has no secret bound to this env var to rotate. The plan
+    /// classified the change as an add rather than a rotation.
+    #[error("sandbox '{name}' has no secret '{env_var}' to rotate")]
+    RotationTargetMissing { name: String, env_var: String },
 }
 
 impl SandboxError {
@@ -243,12 +251,14 @@ impl SandboxError {
                 sandbox: name.clone(),
             }),
             Self::Operation { name, source, .. } => Some(classify_sdk_error(name, &source.0)),
+            // A dropped exec session is a backend-health signal (agent/connectivity).
+            Self::ExecLost { .. } => Some(SandboxCause::Unreachable),
             Self::InvalidSpec { .. }
             | Self::ExecSpawn { .. }
             | Self::ExecStdin { .. }
             | Self::RotationUnsupported { .. }
-            | Self::RotationConflict { .. }
-            | Self::RotationNotApplied { .. } => None,
+            | Self::RotationTargetMissing { .. }
+            | Self::RotationConflict { .. } => None,
         }
     }
 }
@@ -365,6 +375,7 @@ mod tests {
         let spawn = SandboxError::ExecSpawn {
             name: "right-a".to_owned(),
             cmd: "claude".to_owned(),
+            kind: "NotFound".to_owned(),
             message: "no such file".to_owned(),
         };
         assert_eq!(spawn.cause(), None);
@@ -395,7 +406,7 @@ mod tests {
         let err = SandboxError::Operation {
             name: "right-a".to_owned(),
             operation: "exec",
-            source: SdkError(MicrosandboxError::SandboxNotRunning("right-a".to_owned())),
+            source: Box::new(SdkError(MicrosandboxError::SandboxNotRunning("right-a".to_owned()))),
         };
         assert_eq!(
             err.cause(),

--- a/crates/right-sandbox/src/error.rs
+++ b/crates/right-sandbox/src/error.rs
@@ -1,0 +1,407 @@
+//! Error taxonomy for the Agent Sandbox backend.
+//!
+//! [`SandboxError`] is the crate's only error type. Every variant that says
+//! something about backend *health* maps to a [`SandboxCause`] — the small,
+//! operator-facing taxonomy the bot's supervisor and Telegram UX match on
+//! (replacing OpenShell's `GatewayCause`). Caller/config errors (invalid spec,
+//! guest command spawn failure) map to `None`: they are not backend-health
+//! signals, and the supervisor never sees them on bring-up paths.
+
+use std::io;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use microsandbox::MicrosandboxError;
+
+use crate::phase::SandboxPhase;
+
+/// Why the sandbox backend is unusable.
+///
+/// The operator-facing classification of a [`SandboxError`]. Every variant is
+/// either operator-fixable without recreating the sandbox or self-heals on the
+/// supervisor's next bring-up pass.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum SandboxCause {
+    /// The pinned `msb`/`libkrunfw` runtime could not be installed or the
+    /// install is incomplete.
+    #[error("the sandbox runtime failed to install")]
+    RuntimeInstallFailed,
+
+    /// The host lacks a usable hypervisor (Apple Silicon / `/dev/kvm`).
+    #[error("this host cannot run microVMs")]
+    HypervisorUnavailable,
+
+    /// No sandbox with this name exists in the runtime catalog.
+    #[error("sandbox '{sandbox}' does not exist")]
+    SandboxNotFound { sandbox: String },
+
+    /// The sandbox exists but is not in a running phase.
+    #[error("sandbox '{sandbox}' is not running")]
+    SandboxNotRunning { sandbox: String },
+
+    /// The runtime or the in-guest agent could not be reached; the failure is
+    /// inconclusive or transient.
+    #[error("the sandbox runtime is unreachable")]
+    Unreachable,
+}
+
+impl SandboxCause {
+    /// Build the operator-facing diagnosis for this cause: one
+    /// consequence-first summary plus ordered, actionable fixes.
+    pub fn diagnose(&self) -> SandboxDiagnosis {
+        let (summary, fixes): (String, Vec<&str>) = match self {
+            Self::RuntimeInstallFailed => (
+                "the sandbox runtime isn't installed correctly".to_owned(),
+                vec![
+                    "The runtime installs automatically on first use, so this means the download or its verification failed -- check the network connection and try again",
+                    "The runtime lives in ~/.microsandbox; deleting that directory forces a clean reinstall",
+                ],
+            ),
+            Self::HypervisorUnavailable => (
+                "this machine can't run microVMs".to_owned(),
+                vec![
+                    "On macOS this requires Apple Silicon",
+                    "On Linux, KVM must be available: check that /dev/kvm exists and is readable by your user",
+                ],
+            ),
+            Self::SandboxNotFound { sandbox } => (
+                format!("my sandbox '{sandbox}' doesn't exist"),
+                vec![
+                    "I'll recreate it automatically on the next start -- your agent data on the host is preserved",
+                ],
+            ),
+            Self::SandboxNotRunning { sandbox } => (
+                format!("my secure sandbox '{sandbox}' isn't running"),
+                vec![
+                    "I'll restart it automatically -- your data is preserved. If it stays down, recreate the agent's sandbox.",
+                ],
+            ),
+            Self::Unreachable => (
+                "I can't reach the sandbox runtime".to_owned(),
+                vec![
+                    "Check that no other sandbox operation is wedged, then restart the bot",
+                    "If it persists, check the host diagnosis with `msb doctor`",
+                ],
+            ),
+        };
+        SandboxDiagnosis {
+            cause: self.clone(),
+            summary,
+            fixes: fixes.into_iter().map(str::to_owned).collect(),
+        }
+    }
+}
+
+/// A human-facing, cause-specific diagnosis: one consequence-first summary
+/// plus ordered, actionable fixes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxDiagnosis {
+    pub cause: SandboxCause,
+    pub summary: String,
+    pub fixes: Vec<String>,
+}
+
+/// The SDK error behind a sandbox failure.
+///
+/// Opaque by design: consumers render it or chain from it but never name a
+/// microsandbox type, so stage-4 crates never import the SDK.
+#[derive(Debug)]
+pub struct SdkError(pub(crate) MicrosandboxError);
+
+impl std::fmt::Display for SdkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::error::Error for SdkError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.0.source()
+    }
+}
+
+impl From<MicrosandboxError> for SdkError {
+    fn from(error: MicrosandboxError) -> Self {
+        Self(error)
+    }
+}
+
+/// The crate's only error type.
+#[derive(Debug, thiserror::Error)]
+pub enum SandboxError {
+    /// `setup::install()` failed while downloading or verifying the pinned
+    /// runtime into `~/.microsandbox`.
+    #[error("failed to install the pinned microsandbox runtime: {source}")]
+    RuntimeInstall {
+        #[source]
+        source: SdkError,
+    },
+    #[error("failed to lock the runtime-install lockfile {}", path.display())]
+    RuntimeInstallLock { path: PathBuf, source: io::Error },
+
+    /// `setup::install()` returned success but the runtime files are still
+    /// absent — the install cannot be trusted.
+    #[error("the runtime install reported success but is still not present")]
+    RuntimeInstallVerify,
+
+    /// Host preflight (`setup::diagnose()`) found blocking problems.
+    #[error("this host cannot run microVMs: {summary}")]
+    HypervisorUnavailable { summary: String, fixes: Vec<String> },
+
+    /// A [`crate::SandboxSpec`] field failed validation before any SDK call.
+    #[error("invalid sandbox spec: {field}: {reason}")]
+    InvalidSpec { field: &'static str, reason: String },
+
+    /// The named sandbox does not exist in the runtime catalog.
+    #[error("sandbox '{name}' not found")]
+    NotFound { name: String },
+
+    /// The sandbox exists but is in a non-running phase.
+    #[error("sandbox '{name}' is {phase}, not running")]
+    NotRunning { name: String, phase: SandboxPhase },
+
+    /// While waiting for readiness the sandbox entered a terminal phase, so
+    /// it can never become ready without a restart.
+    #[error("sandbox '{name}' reached terminal phase {phase} while waiting to become ready")]
+    TerminalBeforeReady { name: String, phase: SandboxPhase },
+
+    /// Readiness polling exhausted the timeout. The last observed phase is
+    /// preserved so the caller can distinguish "still booting" from "stuck".
+    #[error("sandbox '{name}' did not become ready within {timeout:?} (last phase: {last_phase})")]
+    ReadinessTimeout {
+        name: String,
+        timeout: Duration,
+        last_phase: SandboxPhase,
+    },
+
+    /// A sandbox operation failed at the SDK/runtime layer.
+    #[error("sandbox '{name}': {operation} failed: {source}")]
+    Operation {
+        name: String,
+        operation: &'static str,
+        #[source]
+        source: SdkError,
+    },
+
+    /// The guest command never started (binary missing, bad cwd, guest user
+    /// setup failure). A command-level error: the sandbox itself is healthy.
+    #[error("sandbox '{name}': command '{cmd}' failed to start in the guest: {message}")]
+    ExecSpawn {
+        name: String,
+        cmd: String,
+        message: String,
+    },
+
+    /// Writing to or closing a guest command's stdin failed. The exec session
+    /// is torn down; the sandbox itself may be healthy.
+    #[error("sandbox '{name}': stdin for '{cmd}' failed: {message}")]
+    ExecStdin {
+        name: String,
+        cmd: String,
+        message: String,
+    },
+
+    /// The runtime reported the secret rotation cannot be applied through
+    /// `modify()` at all (e.g. capability missing on an old runtime).
+    #[error("sandbox '{name}': rotating secret '{env_var}' is not supported by the runtime")]
+    RotationUnsupported { name: String, env_var: String },
+
+    /// The rotation plan carried conflicts that must be resolved first.
+    #[error("sandbox '{name}': rotating secret '{env_var}' has conflicts: {details}")]
+    RotationConflict {
+        name: String,
+        env_var: String,
+        details: String,
+    },
+
+    /// The plan announced changes but `apply()` reported none applied.
+    #[error("sandbox '{name}': rotating secret '{env_var}' planned changes but applied none")]
+    RotationNotApplied { name: String, env_var: String },
+}
+
+impl SandboxError {
+    /// The operator-facing backend-health classification, when this error says
+    /// something about backend health.
+    ///
+    /// `None` means the error is a caller/config/command error (invalid spec,
+    /// guest command spawn failure, rotation misuse) and says nothing about
+    /// the backend. Callers that always need a cause fall back to
+    /// [`SandboxCause::Unreachable`], matching the old `GatewayCause`
+    /// "inconclusive" fallback.
+    pub fn cause(&self) -> Option<SandboxCause> {
+        match self {
+            Self::RuntimeInstall { .. }
+            | Self::RuntimeInstallLock { .. }
+            | Self::RuntimeInstallVerify => Some(SandboxCause::RuntimeInstallFailed),
+            Self::HypervisorUnavailable { .. } => Some(SandboxCause::HypervisorUnavailable),
+            Self::NotFound { name } => Some(SandboxCause::SandboxNotFound {
+                sandbox: name.clone(),
+            }),
+            Self::NotRunning { name, .. }
+            | Self::TerminalBeforeReady { name, .. }
+            | Self::ReadinessTimeout { name, .. } => Some(SandboxCause::SandboxNotRunning {
+                sandbox: name.clone(),
+            }),
+            Self::Operation { name, source, .. } => Some(classify_sdk_error(name, &source.0)),
+            Self::InvalidSpec { .. }
+            | Self::ExecSpawn { .. }
+            | Self::ExecStdin { .. }
+            | Self::RotationUnsupported { .. }
+            | Self::RotationConflict { .. }
+            | Self::RotationNotApplied { .. } => None,
+        }
+    }
+}
+
+/// Map an SDK error to the backend-health taxonomy.
+pub(crate) fn classify_sdk_error(name: &str, error: &MicrosandboxError) -> SandboxCause {
+    match error {
+        MicrosandboxError::SandboxNotFound(_) => SandboxCause::SandboxNotFound {
+            sandbox: name.to_owned(),
+        },
+        // A boot failure leaves the sandbox stopped/crashed; the hypervisor
+        // preflight (`diagnose_host`) is what distinguishes a missing
+        // hypervisor from a bad image, so BootStart lands here.
+        MicrosandboxError::SandboxNotRunning(_) | MicrosandboxError::BootStart { .. } => {
+            SandboxCause::SandboxNotRunning {
+                sandbox: name.to_owned(),
+            }
+        }
+        // The pinned runtime tree is incomplete — the install is broken.
+        MicrosandboxError::LibkrunfwNotFound(_) => SandboxCause::RuntimeInstallFailed,
+        _ => SandboxCause::Unreachable,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_failures_classify_as_runtime_install_failed() {
+        let lock = SandboxError::RuntimeInstallLock {
+            path: PathBuf::from("/tmp/x.lock"),
+            source: io::Error::new(io::ErrorKind::PermissionDenied, "denied"),
+        };
+        assert_eq!(lock.cause(), Some(SandboxCause::RuntimeInstallFailed));
+        assert_eq!(
+            SandboxError::RuntimeInstallVerify.cause(),
+            Some(SandboxCause::RuntimeInstallFailed)
+        );
+    }
+
+    #[test]
+    fn lifecycle_errors_classify_with_the_sandbox_name() {
+        let not_found = SandboxError::NotFound {
+            name: "right-a".to_owned(),
+        };
+        assert_eq!(
+            not_found.cause(),
+            Some(SandboxCause::SandboxNotFound {
+                sandbox: "right-a".to_owned()
+            })
+        );
+
+        let timeout = SandboxError::ReadinessTimeout {
+            name: "right-a".to_owned(),
+            timeout: Duration::from_secs(1),
+            last_phase: SandboxPhase::Starting,
+        };
+        assert_eq!(
+            timeout.cause(),
+            Some(SandboxCause::SandboxNotRunning {
+                sandbox: "right-a".to_owned()
+            })
+        );
+
+        let terminal = SandboxError::TerminalBeforeReady {
+            name: "right-b".to_owned(),
+            phase: SandboxPhase::Crashed,
+        };
+        assert_eq!(
+            terminal.cause(),
+            Some(SandboxCause::SandboxNotRunning {
+                sandbox: "right-b".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn sdk_error_classification() {
+        let name = "right-a";
+        assert_eq!(
+            classify_sdk_error(name, &MicrosandboxError::SandboxNotFound(name.to_owned())),
+            SandboxCause::SandboxNotFound {
+                sandbox: name.to_owned()
+            }
+        );
+        assert_eq!(
+            classify_sdk_error(name, &MicrosandboxError::SandboxNotRunning(name.to_owned())),
+            SandboxCause::SandboxNotRunning {
+                sandbox: name.to_owned()
+            }
+        );
+        assert_eq!(
+            classify_sdk_error(
+                name,
+                &MicrosandboxError::LibkrunfwNotFound("libkrunfw.efi".to_owned())
+            ),
+            SandboxCause::RuntimeInstallFailed
+        );
+        assert_eq!(
+            classify_sdk_error(name, &MicrosandboxError::Custom("weird".to_owned())),
+            SandboxCause::Unreachable
+        );
+    }
+
+    #[test]
+    fn caller_and_command_errors_have_no_backend_cause() {
+        let invalid = SandboxError::InvalidSpec {
+            field: "name",
+            reason: "empty".to_owned(),
+        };
+        assert_eq!(invalid.cause(), None);
+
+        let spawn = SandboxError::ExecSpawn {
+            name: "right-a".to_owned(),
+            cmd: "claude".to_owned(),
+            message: "no such file".to_owned(),
+        };
+        assert_eq!(spawn.cause(), None);
+    }
+
+    #[test]
+    fn every_cause_produces_a_nonempty_diagnosis() {
+        let causes = [
+            SandboxCause::RuntimeInstallFailed,
+            SandboxCause::HypervisorUnavailable,
+            SandboxCause::SandboxNotFound {
+                sandbox: "right-a".to_owned(),
+            },
+            SandboxCause::SandboxNotRunning {
+                sandbox: "right-a".to_owned(),
+            },
+            SandboxCause::Unreachable,
+        ];
+        for cause in causes {
+            let diagnosis = cause.diagnose();
+            assert!(!diagnosis.summary.is_empty(), "{cause} summary");
+            assert!(!diagnosis.fixes.is_empty(), "{cause} fixes");
+        }
+    }
+
+    #[test]
+    fn operation_errors_classify_through_the_sdk_source() {
+        let err = SandboxError::Operation {
+            name: "right-a".to_owned(),
+            operation: "exec",
+            source: SdkError(MicrosandboxError::SandboxNotRunning("right-a".to_owned())),
+        };
+        assert_eq!(
+            err.cause(),
+            Some(SandboxCause::SandboxNotRunning {
+                sandbox: "right-a".to_owned()
+            })
+        );
+    }
+}

--- a/crates/right-sandbox/src/exec.rs
+++ b/crates/right-sandbox/src/exec.rs
@@ -1,0 +1,343 @@
+//! Command execution inside an Agent Sandbox.
+//!
+//! Two surfaces: [`SandboxHandle::exec`](crate::SandboxHandle::exec) collects
+//! a finished command's output; [`SandboxHandle::exec_stream`](crate::SandboxHandle::exec_stream)
+//! is the turn transport — a live event stream plus an optional chunked
+//! stdin writer.
+//!
+//! The stdin chunking is load-bearing (stage-1 correction 5): the SDK's
+//! `ExecSink::write` maps one call to one protocol frame capped at
+//! [`PROTOCOL_FRAME_MAX_BYTES`], and an oversized write tears the exec
+//! session down. [`ChunkedStdin`] chunks below the cap.
+
+use std::time::Duration;
+
+use microsandbox::sandbox::ExecOptionsBuilder;
+use microsandbox::sandbox::exec::ExecSink;
+use microsandbox::ExecHandle;
+use crate::error::SandboxError;
+
+/// The SDK's protocol frame cap: one `ExecSink::write` becomes one frame.
+pub const PROTOCOL_FRAME_MAX_BYTES: usize = 4 * 1024 * 1024;
+
+/// Chunk size the stdin writer uses: far below the frame cap, proven in the
+/// stage-1 probe (1.2 MiB pushed in 64 KiB chunks while stdout streamed).
+pub const STDIN_CHUNK_BYTES: usize = 64 * 1024;
+
+const _: () = assert!(
+    STDIN_CHUNK_BYTES < PROTOCOL_FRAME_MAX_BYTES,
+    "stdin chunks must stay below the protocol frame cap"
+);
+
+/// How a command's stdin is wired.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum Stdin {
+    /// No stdin (`/dev/null`).
+    #[default]
+    Null,
+
+    /// A pipe the caller writes through [`ChunkedStdin`].
+    Pipe,
+}
+
+/// A command to run in the guest.
+#[derive(Debug, Clone, Default)]
+pub struct ExecRequest {
+    /// Program path in the guest (e.g. `"/bin/sh"`).
+    pub cmd: String,
+
+    /// Arguments, passed through unquoted (no shell).
+    pub args: Vec<String>,
+
+    /// Working directory; defaults to the sandbox's configured workdir.
+    pub cwd: Option<String>,
+
+    /// Guest user override for this command (`"1000"`, `"sandbox"`,
+    /// `"1000:1000"`). Provisioning execs run as root (`"0"`); agent execs
+    /// use the sandbox's default user.
+    pub user: Option<String>,
+
+    /// Per-command environment, merged over the sandbox env.
+    pub env: Vec<(String, String)>,
+
+    /// Stdin wiring.
+    pub stdin: Stdin,
+
+    /// Hard cap on runtime; the guest process is SIGKILLed on expiry.
+    pub timeout: Option<Duration>,
+}
+
+impl ExecRequest {
+    /// A request for `cmd` with no arguments and null stdin.
+    pub fn new(cmd: impl Into<String>) -> Self {
+        Self {
+            cmd: cmd.into(),
+            ..Self::default()
+        }
+    }
+}
+
+/// One event from a streaming exec session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExecEvent {
+    /// The guest process started.
+    Started {
+        /// Guest PID.
+        pid: u32,
+    },
+
+    /// A chunk of stdout.
+    Stdout(Vec<u8>),
+
+    /// A chunk of stderr.
+    Stderr(Vec<u8>),
+
+    /// The process exited with this code. Terminal.
+    Exited {
+        /// Process exit code.
+        code: i32,
+    },
+}
+
+/// A finished command's output. A non-zero exit code is data, not an error.
+#[derive(Debug, Clone)]
+pub struct ExecOutcome {
+    /// Process exit code.
+    pub code: i32,
+
+    /// Everything the process wrote to stdout.
+    pub stdout: Vec<u8>,
+
+    /// Everything the process wrote to stderr.
+    pub stderr: Vec<u8>,
+}
+
+impl ExecOutcome {
+    /// True when the process exited 0.
+    pub fn success(&self) -> bool {
+        self.code == 0
+    }
+}
+
+/// A live streaming exec session.
+///
+/// Spawn failures surface as `Err(SandboxError::ExecSpawn)` from
+/// [`next_event`](Self::next_event)/[`wait`](Self::wait) rather than as a
+/// `Started`-less stream; a non-zero exit is an [`ExecEvent::Exited`], never
+/// an error.
+pub struct ExecStream {
+    name: String,
+    cmd: String,
+    inner: ExecHandle,
+}
+
+impl ExecStream {
+    pub(crate) fn new(name: String, cmd: String, inner: ExecHandle) -> Self {
+        Self { name, cmd, inner }
+    }
+
+    /// The next event, or `None` after the session ends.
+    ///
+    /// Guest-side spawn failures and stdin failures are errors, not events —
+    /// FAIL FAST applies to the stream too.
+    pub async fn next_event(&mut self) -> Result<Option<ExecEvent>, SandboxError> {
+        match self.inner.recv().await {
+            None => Ok(None),
+            Some(microsandbox::ExecEvent::Started { pid }) => Ok(Some(ExecEvent::Started { pid })),
+            Some(microsandbox::ExecEvent::Stdout(bytes)) => {
+                Ok(Some(ExecEvent::Stdout(bytes.to_vec())))
+            }
+            Some(microsandbox::ExecEvent::Stderr(bytes)) => {
+                Ok(Some(ExecEvent::Stderr(bytes.to_vec())))
+            }
+            Some(microsandbox::ExecEvent::Exited { code }) => Ok(Some(ExecEvent::Exited { code })),
+            Some(microsandbox::ExecEvent::Failed(failed)) => Err(SandboxError::ExecSpawn {
+                name: self.name.clone(),
+                cmd: self.cmd.clone(),
+                message: failed.message,
+            }),
+            Some(microsandbox::ExecEvent::StdinError(err)) => Err(SandboxError::ExecStdin {
+                name: self.name.clone(),
+                cmd: self.cmd.clone(),
+                message: format!("{err:?}"),
+            }),
+        }
+    }
+
+    /// Take the stdin writer. `Some` exactly once, only when the request
+    /// asked for [`Stdin::Pipe`].
+    pub fn take_stdin(&mut self) -> Option<ChunkedStdin> {
+        self.inner
+            .take_stdin()
+            .map(|sink| ChunkedStdin {
+                name: self.name.clone(),
+                cmd: self.cmd.clone(),
+                sink,
+            })
+    }
+
+    /// Drain the event stream and return the exit code. Output events are
+    /// discarded; callers that want output drive [`next_event`](Self::next_event)
+    /// themselves.
+    pub async fn wait(&mut self) -> Result<i32, SandboxError> {
+        loop {
+            match self.next_event().await? {
+                Some(ExecEvent::Exited { code }) => return Ok(code),
+                None => {
+                    return Err(SandboxError::ExecSpawn {
+                        name: self.name.clone(),
+                        cmd: self.cmd.clone(),
+                        message: "the exec session ended without an exit event".to_owned(),
+                    });
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Send a signal to the guest process.
+    pub async fn signal(&self, signal: i32) -> Result<(), SandboxError> {
+        self.inner
+            .signal(signal)
+            .await
+            .map_err(|source| SandboxError::Operation {
+                name: self.name.clone(),
+                operation: "exec signal",
+                source: source.into(),
+            })
+    }
+
+    /// SIGKILL the guest process.
+    pub async fn kill(&self) -> Result<(), SandboxError> {
+        self.inner
+            .kill()
+            .await
+            .map_err(|source| SandboxError::Operation {
+                name: self.name.clone(),
+                operation: "exec kill",
+                source: source.into(),
+            })
+    }
+}
+
+/// A chunked writer for a guest process's stdin.
+///
+/// Writes of any size are safe: data goes out in [`STDIN_CHUNK_BYTES`]
+/// frames, below the protocol cap that would otherwise tear the session down.
+pub struct ChunkedStdin {
+    name: String,
+    cmd: String,
+    sink: ExecSink,
+}
+
+impl ChunkedStdin {
+    /// Write all of `data`, chunking below the protocol frame cap. Empty
+    /// input writes nothing (an empty write is the SDK's EOF marker — use
+    /// [`close`](Self::close) for that).
+    pub async fn write_all(&self, data: &[u8]) -> Result<(), SandboxError> {
+        for chunk in stdin_chunks(data) {
+            self.sink
+                .write(chunk)
+                .await
+                .map_err(|source| SandboxError::ExecStdin {
+                    name: self.name.clone(),
+                    cmd: self.cmd.clone(),
+                    message: format!("{source}"),
+                })?;
+        }
+        Ok(())
+    }
+
+    /// Send EOF and consume the writer.
+    pub async fn close(self) -> Result<(), SandboxError> {
+        self.sink
+            .close()
+            .await
+            .map_err(|source| SandboxError::ExecStdin {
+                name: self.name.clone(),
+                cmd: self.cmd.clone(),
+                message: format!("{source}"),
+            })
+    }
+}
+
+/// Split `data` into chunks of at most [`STDIN_CHUNK_BYTES`].
+fn stdin_chunks(data: &[u8]) -> std::slice::Chunks<'_, u8> {
+    data.chunks(STDIN_CHUNK_BYTES)
+}
+
+/// Apply a request to an SDK exec-options builder.
+pub(crate) fn apply_request(
+    mut options: ExecOptionsBuilder,
+    request: &ExecRequest,
+) -> ExecOptionsBuilder {
+    options = options.args(request.args.iter().cloned());
+    if let Some(cwd) = &request.cwd {
+        options = options.cwd(cwd);
+    }
+    if let Some(user) = &request.user {
+        options = options.user(user);
+    }
+    for (key, value) in &request.env {
+        options = options.env(key, value);
+    }
+    if let Some(timeout) = request.timeout {
+        options = options.timeout(timeout);
+    }
+    match request.stdin {
+        Stdin::Null => options.stdin_null(),
+        Stdin::Pipe => options.stdin_pipe(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chunk_size_stays_below_the_frame_cap() {
+        assert!(STDIN_CHUNK_BYTES < PROTOCOL_FRAME_MAX_BYTES);
+        assert_eq!(STDIN_CHUNK_BYTES, 64 * 1024);
+    }
+
+    #[test]
+    fn empty_input_produces_no_chunks() {
+        // An empty SDK write is the EOF marker, so the chunker must not emit
+        // one for empty input.
+        assert_eq!(stdin_chunks(&[]).count(), 0);
+    }
+
+    #[test]
+    fn small_input_is_one_chunk() {
+        let data = vec![b'x'; STDIN_CHUNK_BYTES - 1];
+        let chunks: Vec<&[u8]> = stdin_chunks(&data).collect();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].len(), STDIN_CHUNK_BYTES - 1);
+    }
+
+    #[test]
+    fn exact_multiple_produces_full_chunks_only() {
+        let data = vec![b'x'; 2 * STDIN_CHUNK_BYTES];
+        let chunks: Vec<&[u8]> = stdin_chunks(&data).collect();
+        assert_eq!(chunks.len(), 2);
+        assert!(chunks.iter().all(|chunk| chunk.len() == STDIN_CHUNK_BYTES));
+    }
+
+    #[test]
+    fn oversized_input_chunks_below_the_cap() {
+        // Larger than the protocol frame cap: the whole point of the writer.
+        let data = vec![b'x'; 5 * 1024 * 1024 + 7];
+        let chunks: Vec<&[u8]> = stdin_chunks(&data).collect();
+        assert_eq!(chunks.len(), 81);
+        assert!(
+            chunks.iter().all(|chunk| chunk.len() <= STDIN_CHUNK_BYTES),
+            "every chunk stays below the cap"
+        );
+        assert_eq!(chunks.last().expect("last chunk").len(), 7);
+        assert_eq!(
+            chunks.iter().map(|chunk| chunk.len()).sum::<usize>(),
+            data.len(),
+            "chunking is lossless"
+        );
+    }
+}

--- a/crates/right-sandbox/src/exec.rs
+++ b/crates/right-sandbox/src/exec.rs
@@ -317,8 +317,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn chunk_size_stays_below_the_frame_cap() {
-        assert!(STDIN_CHUNK_BYTES < PROTOCOL_FRAME_MAX_BYTES);
+    fn chunk_size_matches_the_proven_probe_value() {
+        // The const-assert above already guarantees chunk < frame cap; this
+        // pins the specific 64 KiB value stage-1 proved out.
         assert_eq!(STDIN_CHUNK_BYTES, 64 * 1024);
     }
 

--- a/crates/right-sandbox/src/exec.rs
+++ b/crates/right-sandbox/src/exec.rs
@@ -154,13 +154,20 @@ impl ExecStream {
             Some(microsandbox::ExecEvent::Failed(failed)) => Err(SandboxError::ExecSpawn {
                 name: self.name.clone(),
                 cmd: self.cmd.clone(),
-                message: failed.message,
+                kind: format!("{:?}", failed.kind),
+                message: format_exec_failed(&failed),
             }),
-            Some(microsandbox::ExecEvent::StdinError(err)) => Err(SandboxError::ExecStdin {
-                name: self.name.clone(),
-                cmd: self.cmd.clone(),
-                message: format!("{err:?}"),
-            }),
+            Some(microsandbox::ExecEvent::StdinError(err)) => {
+                let message = match &err.errno_name {
+                    Some(errno) => format!("{} [{errno}]", err.message),
+                    None => err.message,
+                };
+                Err(SandboxError::ExecStdin {
+                    name: self.name.clone(),
+                    cmd: self.cmd.clone(),
+                    message,
+                })
+            }
         }
     }
 
@@ -184,10 +191,9 @@ impl ExecStream {
             match self.next_event().await? {
                 Some(ExecEvent::Exited { code }) => return Ok(code),
                 None => {
-                    return Err(SandboxError::ExecSpawn {
+                    return Err(SandboxError::ExecLost {
                         name: self.name.clone(),
                         cmd: self.cmd.clone(),
-                        message: "the exec session ended without an exit event".to_owned(),
                     });
                 }
                 _ => {}
@@ -203,7 +209,7 @@ impl ExecStream {
             .map_err(|source| SandboxError::Operation {
                 name: self.name.clone(),
                 operation: "exec signal",
-                source: source.into(),
+                source: Box::new(crate::error::SdkError(source)),
             })
     }
 
@@ -215,7 +221,7 @@ impl ExecStream {
             .map_err(|source| SandboxError::Operation {
                 name: self.name.clone(),
                 operation: "exec kill",
-                source: source.into(),
+                source: Box::new(crate::error::SdkError(source)),
             })
     }
 }
@@ -242,7 +248,7 @@ impl ChunkedStdin {
                 .map_err(|source| SandboxError::ExecStdin {
                     name: self.name.clone(),
                     cmd: self.cmd.clone(),
-                    message: format!("{source}"),
+                    message: format!("{source:#}"),
                 })?;
         }
         Ok(())
@@ -256,8 +262,24 @@ impl ChunkedStdin {
             .map_err(|source| SandboxError::ExecStdin {
                 name: self.name.clone(),
                 cmd: self.cmd.clone(),
-                message: format!("{source}"),
+                message: format!("{source:#}"),
             })
+    }
+}
+
+/// Render an SDK `ExecFailed` with its errno/stage context appended.
+///
+/// `kind` is carried separately on [`SandboxError::ExecSpawn`]; this formats
+/// only the human message plus the structured `errno_name`/`stage` when the
+/// agentd classifier populated them.
+pub(crate) fn format_exec_failed(
+    failed: &microsandbox::protocol::exec::ExecFailed,
+) -> String {
+    match (&failed.errno_name, &failed.stage) {
+        (Some(errno), Some(stage)) => format!("{} [{errno} at {stage}]", failed.message),
+        (Some(errno), None) => format!("{} [{errno}]", failed.message),
+        (None, Some(stage)) => format!("{} [at {stage}]", failed.message),
+        (None, None) => failed.message.clone(),
     }
 }
 

--- a/crates/right-sandbox/src/fs.rs
+++ b/crates/right-sandbox/src/fs.rs
@@ -1,0 +1,170 @@
+//! Guest filesystem access through the SDK's fs API.
+//!
+//! The microVM boundary replaces landlock: there are no host bind mounts, so
+//! every byte crosses via this API (large payloads chunk internally at the
+//! SDK's 3 MiB fs-chunk size). Provisioning writes the platform tree as root
+//! and then `chmod a-w`s it — the fs API runs as the sandbox's agentd (root),
+//! so the guest-side `sandbox` user cannot modify it; agent-owned content
+//! lives in the agent's subdirectory.
+
+use std::path::Path;
+
+use microsandbox::sandbox::{FsEntry, FsEntryKind as SdkFsEntryKind, FsMetadata};
+
+use crate::error::SandboxError;
+use crate::handle::SandboxHandle;
+
+/// Kind of a guest filesystem entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FsEntryKind {
+    /// Regular file.
+    File,
+
+    /// Directory.
+    Directory,
+
+    /// Symbolic link.
+    Symlink,
+
+    /// Device, socket, etc.
+    Other,
+}
+
+impl From<SdkFsEntryKind> for FsEntryKind {
+    fn from(kind: SdkFsEntryKind) -> Self {
+        match kind {
+            SdkFsEntryKind::File => Self::File,
+            SdkFsEntryKind::Directory => Self::Directory,
+            SdkFsEntryKind::Symlink => Self::Symlink,
+            SdkFsEntryKind::Other => Self::Other,
+        }
+    }
+}
+
+/// Metadata about a guest filesystem entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FsEntryInfo {
+    /// Guest path (the requested path for `fs_stat`).
+    pub path: String,
+
+    /// Entry kind.
+    pub kind: FsEntryKind,
+
+    /// Size in bytes.
+    pub size: u64,
+
+    /// Unix permission bits.
+    pub mode: u32,
+
+    /// Owner uid.
+    pub uid: u32,
+
+    /// Owner gid.
+    pub gid: u32,
+}
+
+impl From<FsEntry> for FsEntryInfo {
+    fn from(entry: FsEntry) -> Self {
+        Self {
+            path: entry.path,
+            kind: entry.kind.into(),
+            size: entry.size,
+            mode: entry.mode,
+            uid: entry.uid,
+            gid: entry.gid,
+        }
+    }
+}
+
+impl FsEntryInfo {
+    fn from_metadata(path: &str, metadata: FsMetadata) -> Self {
+        Self {
+            path: path.to_owned(),
+            kind: metadata.kind.into(),
+            size: metadata.size,
+            mode: metadata.mode,
+            uid: metadata.uid,
+            gid: metadata.gid,
+        }
+    }
+}
+
+impl SandboxHandle {
+    /// Read an entire guest file into memory.
+    pub async fn fs_read(&self, path: &str) -> Result<Vec<u8>, SandboxError> {
+        self.fs_op("fs read", self.sdk().fs().read(path))
+            .await
+            .map(|bytes| bytes.to_vec())
+    }
+
+    /// Read an entire guest file as UTF-8.
+    pub async fn fs_read_to_string(&self, path: &str) -> Result<String, SandboxError> {
+        self.fs_op("fs read", self.sdk().fs().read_to_string(path))
+            .await
+    }
+
+    /// Write `data` to a guest file, creating it (not its parents) if needed.
+    pub async fn fs_write(&self, path: &str, data: &[u8]) -> Result<(), SandboxError> {
+        self.fs_op("fs write", self.sdk().fs().write(path, data))
+            .await
+    }
+
+    /// List the immediate children of a guest directory (non-recursive).
+    pub async fn fs_list(&self, path: &str) -> Result<Vec<FsEntryInfo>, SandboxError> {
+        let entries = self.fs_op("fs list", self.sdk().fs().list(path)).await?;
+        Ok(entries.into_iter().map(FsEntryInfo::from).collect())
+    }
+
+    /// Create a guest directory and its parents.
+    pub async fn fs_mkdir(&self, path: &str) -> Result<(), SandboxError> {
+        self.fs_op("fs mkdir", self.sdk().fs().mkdir(path)).await
+    }
+
+    /// Delete a single guest file.
+    pub async fn fs_remove(&self, path: &str) -> Result<(), SandboxError> {
+        self.fs_op("fs remove", self.sdk().fs().remove(path)).await
+    }
+
+    /// Delete a guest directory recursively.
+    pub async fn fs_remove_dir(&self, path: &str) -> Result<(), SandboxError> {
+        self.fs_op("fs remove_dir", self.sdk().fs().remove_dir(path))
+            .await
+    }
+
+    /// Whether a guest path exists.
+    pub async fn fs_exists(&self, path: &str) -> Result<bool, SandboxError> {
+        self.fs_op("fs exists", self.sdk().fs().exists(path)).await
+    }
+
+    /// Stat a guest path.
+    pub async fn fs_stat(&self, path: &str) -> Result<FsEntryInfo, SandboxError> {
+        let metadata = self.fs_op("fs stat", self.sdk().fs().stat(path)).await?;
+        Ok(FsEntryInfo::from_metadata(path, metadata))
+    }
+
+    /// Copy a host file into the guest.
+    pub async fn fs_copy_from_host(
+        &self,
+        host_path: impl AsRef<Path>,
+        guest_path: &str,
+    ) -> Result<(), SandboxError> {
+        self.fs_op(
+            "fs copy_from_host",
+            self.sdk().fs().copy_from_host(host_path, guest_path),
+        )
+        .await
+    }
+
+    /// Copy a guest file to the host.
+    pub async fn fs_copy_to_host(
+        &self,
+        guest_path: &str,
+        host_path: impl AsRef<Path>,
+    ) -> Result<(), SandboxError> {
+        self.fs_op(
+            "fs copy_to_host",
+            self.sdk().fs().copy_to_host(guest_path, host_path),
+        )
+        .await
+    }
+}

--- a/crates/right-sandbox/src/handle.rs
+++ b/crates/right-sandbox/src/handle.rs
@@ -73,7 +73,7 @@ impl SandboxHandle {
                     .map_err(|source| SandboxError::Operation {
                         name: spec.name.clone(),
                         operation: "create",
-                        source: source.into(),
+                        source: Box::new(crate::error::SdkError(source)),
                     })?;
                 Ok(Self::from_sandbox(spec.name.clone(), sandbox))
             }
@@ -263,7 +263,6 @@ impl SandboxHandle {
     ) -> Result<SecretRotation, SandboxError> {
         binding.validate_ref()?;
 
-
         let plan = self
             .sandbox
             .modify()
@@ -290,12 +289,21 @@ impl SandboxHandle {
         }
 
         let mut disposition = RotationDisposition::Live;
-        let mut saw_change = false;
         for change in &plan.changes {
             let PlannedChange::Secret(secret) = change else {
                 continue;
             };
-            saw_change = true;
+            // A rotation re-asserts only env+source, so a sandbox that has the
+            // binding classifies the change as Rotated. Anything else (notably
+            // Added) means the sandbox has no such secret — surface that
+            // directly instead of the SDK's downstream "needs at least one
+            // allowed host" conflict.
+            if secret.change != microsandbox::SecretChangeKind::Rotated {
+                return Err(SandboxError::RotationTargetMissing {
+                    name: self.name.clone(),
+                    env_var: binding.env_var.clone(),
+                });
+            }
             match secret.disposition {
                 ModificationDisposition::Live => {}
                 ModificationDisposition::NextStart => {
@@ -326,13 +334,6 @@ impl SandboxHandle {
             .apply()
             .await
             .map_err(|source| operation_error(&self.name, "rotate secret", source))?;
-
-        if saw_change && !applied.applied {
-            return Err(SandboxError::RotationNotApplied {
-                name: self.name.clone(),
-                env_var: binding.env_var.clone(),
-            });
-        }
 
         Ok(SecretRotation {
             disposition,
@@ -368,7 +369,8 @@ impl SandboxHandle {
             MicrosandboxError::ExecFailed(failed) => SandboxError::ExecSpawn {
                 name: self.name.clone(),
                 cmd: cmd.to_owned(),
-                message: failed.message,
+                kind: format!("{:?}", failed.kind),
+                message: crate::exec::format_exec_failed(&failed),
             },
             source => operation_error(&self.name, operation, source),
         }
@@ -448,6 +450,6 @@ fn operation_error(
     SandboxError::Operation {
         name: name.to_owned(),
         operation,
-        source: crate::error::SdkError(source),
+        source: Box::new(crate::error::SdkError(source)),
     }
 }

--- a/crates/right-sandbox/src/handle.rs
+++ b/crates/right-sandbox/src/handle.rs
@@ -275,19 +275,6 @@ impl SandboxHandle {
             .await
             .map_err(|source| operation_error(&self.name, "plan secret rotation", source))?;
 
-        if !plan.conflicts.is_empty() {
-            return Err(SandboxError::RotationConflict {
-                name: self.name.clone(),
-                env_var: binding.env_var.clone(),
-                details: plan
-                    .conflicts
-                    .iter()
-                    .map(|conflict| format!("{}: {}", conflict.field, conflict.message))
-                    .collect::<Vec<_>>()
-                    .join("; "),
-            });
-        }
-
         let mut disposition = RotationDisposition::Live;
         for change in &plan.changes {
             let PlannedChange::Secret(secret) = change else {
@@ -295,9 +282,11 @@ impl SandboxHandle {
             };
             // A rotation re-asserts only env+source, so a sandbox that has the
             // binding classifies the change as Rotated. Anything else (notably
-            // Added) means the sandbox has no such secret — surface that
-            // directly instead of the SDK's downstream "needs at least one
-            // allowed host" conflict.
+            // Added) means the sandbox has no such secret. This must be checked
+            // BEFORE the conflicts gate: the SDK also emits a "needs at least
+            // one allowed host" conflict for an Added secret, and Right's
+            // rotation patch never sets hosts, so the conflict would otherwise
+            // mask the real "no such binding" error.
             if secret.change != microsandbox::SecretChangeKind::Rotated {
                 return Err(SandboxError::RotationTargetMissing {
                     name: self.name.clone(),
@@ -321,6 +310,19 @@ impl SandboxHandle {
                     });
                 }
             }
+        }
+
+        if !plan.conflicts.is_empty() {
+            return Err(SandboxError::RotationConflict {
+                name: self.name.clone(),
+                env_var: binding.env_var.clone(),
+                details: plan
+                    .conflicts
+                    .iter()
+                    .map(|conflict| format!("{}: {}", conflict.field, conflict.message))
+                    .collect::<Vec<_>>()
+                    .join("; "),
+            });
         }
 
         let applied = self

--- a/crates/right-sandbox/src/handle.rs
+++ b/crates/right-sandbox/src/handle.rs
@@ -1,0 +1,453 @@
+//! The unified Agent Sandbox handle.
+//!
+//! One [`SandboxHandle`] replaces the OpenShell-era `resolved_sandbox` +
+//! `ssh_config_path` pair: construction creates the sandbox detached or
+//! re-attaches by name, and every operation (exec, fs, secrets, health, logs)
+//! goes through the SDK — no SSH anywhere.
+//!
+//! Readiness semantics (the brief's lifecycle contract): the SDK's create and
+//! `start_detached` already block until the guest agent is serving and fail
+//! with a boot error if the VM dies first, so a freshly created/started
+//! sandbox needs no extra readiness wait. The poll exists for the *attach
+//! race* — a sandbox left in `Created`/`Starting` by another process — and it
+//! treats a terminal phase as an immediate error and preserves the last
+//! observed phase in a timeout.
+
+use std::time::{Duration, Instant};
+
+use microsandbox::{MicrosandboxError, ModificationDisposition, PlannedChange, Sandbox};
+
+use crate::error::SandboxError;
+use crate::exec::{ExecOutcome, ExecRequest, ExecStream, apply_request};
+use crate::phase::SandboxPhase;
+use crate::secrets::{RotationDisposition, SecretBinding, SecretRotation};
+use crate::spec::SandboxSpec;
+
+/// How long readiness polling waits for a mid-boot sandbox to come up.
+///
+/// Distinct from the SDK's own 180s agent-relay deadline inside create/start:
+/// this covers only the attach-race phases (`Created`/`Starting`), which the
+/// local backend passes through in well under a second. Stage-1 measured boot
+/// at ~10s with an explicit 16 GiB writable layer, so the default leaves
+/// comfortable headroom for slow first boots.
+pub const DEFAULT_READY_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Interval between readiness polls.
+const READINESS_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Grace period given to a sandbox to stop during destroy before it is
+/// killed (matches the stage-1 probe cleanup timeout).
+const DESTROY_KILL_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// An owned connection to an Agent Sandbox.
+///
+/// The wrapped SDK sandbox runs detached: it survives this process exiting,
+/// and dropping the handle does not stop the sandbox. Lifecycle is explicit —
+/// [`stop`](Self::stop)/[`destroy`](Self::destroy).
+pub struct SandboxHandle {
+    name: String,
+    sandbox: Sandbox,
+}
+
+impl SandboxHandle {
+    /// Create the sandbox from `spec` detached, or attach to the existing
+    /// sandbox of the same name.
+    ///
+    /// Attach wins over create: an existing sandbox is used as-is (the
+    /// supervisor owns config-drift reconciliation). A sandbox found in a
+    /// non-running phase is started from its persisted config; one found
+    /// mid-boot is awaited per [`DEFAULT_READY_TIMEOUT`].
+    pub async fn create_or_attach(spec: &SandboxSpec) -> Result<Self, SandboxError> {
+        spec.validate()?;
+        match Self::attach(&spec.name).await {
+            Ok(handle) => {
+                tracing::debug!(sandbox = %spec.name, "attached to existing sandbox");
+                Ok(handle)
+            }
+            Err(SandboxError::NotFound { .. }) => {
+                tracing::info!(sandbox = %spec.name, "creating sandbox");
+                let sandbox = spec
+                    .to_builder()?
+                    .create_detached()
+                    .await
+                    .map_err(|source| SandboxError::Operation {
+                        name: spec.name.clone(),
+                        operation: "create",
+                        source: source.into(),
+                    })?;
+                Ok(Self::from_sandbox(spec.name.clone(), sandbox))
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Attach to an existing sandbox by name, starting it when stopped.
+    ///
+    /// This is the bot's restart path: sandboxes do not auto-start on host
+    /// reboot, so the supervisor re-attaches by name and this starts the
+    /// stopped sandbox from its persisted config.
+    pub async fn attach(name: &str) -> Result<Self, SandboxError> {
+        let handle = Sandbox::get(name).await.map_err(|e| get_error(name, e))?;
+        let phase = SandboxPhase::from(handle.status_snapshot());
+        let sandbox = match phase {
+            SandboxPhase::Running | SandboxPhase::Draining => handle
+                .connect()
+                .await
+                .map_err(|source| operation_error(name, "connect", source))?,
+            SandboxPhase::Stopped | SandboxPhase::Crashed => {
+                tracing::info!(sandbox = %name, phase = %phase, "starting stopped sandbox");
+                handle
+                    .start_detached()
+                    .await
+                    .map_err(|source| operation_error(name, "start", source))?
+            }
+            SandboxPhase::Created | SandboxPhase::Starting => {
+                wait_ready_by_name(name, DEFAULT_READY_TIMEOUT).await?;
+                let fresh = Sandbox::get(name).await.map_err(|e| get_error(name, e))?;
+                fresh
+                    .connect()
+                    .await
+                    .map_err(|source| operation_error(name, "connect", source))?
+            }
+            SandboxPhase::Paused => {
+                return Err(SandboxError::NotRunning {
+                    name: name.to_owned(),
+                    phase,
+                });
+            }
+        };
+        Ok(Self::from_sandbox(name.to_owned(), sandbox))
+    }
+
+    fn from_sandbox(name: String, sandbox: Sandbox) -> Self {
+        Self { name, sandbox }
+    }
+
+    /// The sandbox name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The wrapped SDK sandbox handle (crate-internal consumers only).
+    pub(crate) fn sdk(&self) -> &Sandbox {
+        &self.sandbox
+    }
+
+    /// The sandbox's current lifecycle phase, refreshed from the runtime
+    /// catalog.
+    pub async fn status(&self) -> Result<SandboxPhase, SandboxError> {
+        let handle = Sandbox::get(&self.name)
+            .await
+            .map_err(|e| get_error(&self.name, e))?;
+        Ok(SandboxPhase::from(handle.status_snapshot()))
+    }
+
+    /// Wait until the sandbox is running.
+    ///
+    /// A terminal phase is returned immediately as
+    /// [`SandboxError::TerminalBeforeReady`]; a timeout preserves the last
+    /// observed phase in [`SandboxError::ReadinessTimeout`] — never a bare
+    /// bool.
+    pub async fn wait_ready(&self, timeout: Duration) -> Result<(), SandboxError> {
+        wait_ready_by_name(&self.name, timeout).await
+    }
+
+    /// Stop the sandbox gracefully, escalating to a kill. Idempotent: an
+    /// already-terminal sandbox is a no-op.
+    pub async fn stop(&self) -> Result<(), SandboxError> {
+        self.sandbox
+            .stop()
+            .await
+            .map_err(|source| operation_error(&self.name, "stop", source))
+    }
+
+    /// Stop (killing if needed) and delete the sandbox and its state.
+    ///
+    /// Succeeds when the sandbox does not exist, so it is safe to call after
+    /// a failed bring-up.
+    pub async fn destroy(&self) -> Result<(), SandboxError> {
+        let handle = match Sandbox::get(&self.name).await {
+            Ok(handle) => handle,
+            Err(MicrosandboxError::SandboxNotFound(_)) => return Ok(()),
+            Err(source) => return Err(operation_error(&self.name, "get", source)),
+        };
+        if !SandboxPhase::from(handle.status_snapshot()).is_terminal() {
+            handle
+                .kill_with_timeout(DESTROY_KILL_TIMEOUT)
+                .await
+                .map_err(|source| operation_error(&self.name, "kill", source))?;
+        }
+        match Sandbox::remove(&self.name).await {
+            Ok(()) => Ok(()),
+            Err(MicrosandboxError::SandboxNotFound(_)) => Ok(()),
+            Err(source) => Err(operation_error(&self.name, "remove", source)),
+        }
+    }
+
+    /// Run a command to completion and collect its output.
+    pub async fn exec(&self, request: &ExecRequest) -> Result<ExecOutcome, SandboxError> {
+        let output = self
+            .sandbox
+            .exec_with(&request.cmd, |options| apply_request(options, request))
+            .await
+            .map_err(|source| self.exec_error("exec", &request.cmd, source))?;
+        Ok(ExecOutcome {
+            code: output.status().code,
+            stdout: output.stdout_bytes().to_vec(),
+            stderr: output.stderr_bytes().to_vec(),
+        })
+    }
+
+    /// Start a streaming exec session: live stdout/stderr events plus an
+    /// optional chunked stdin writer.
+    pub async fn exec_stream(&self, request: &ExecRequest) -> Result<ExecStream, SandboxError> {
+        let inner = self
+            .sandbox
+            .exec_stream_with(&request.cmd, |options| apply_request(options, request))
+            .await
+            .map_err(|source| self.exec_error("exec_stream", &request.cmd, source))?;
+        Ok(ExecStream::new(
+            self.name.clone(),
+            request.cmd.clone(),
+            inner,
+        ))
+    }
+
+    /// Health snapshot: refreshed running phase plus memory and
+    /// writable-layer figures.
+    ///
+    /// CPU is deliberately absent: the SDK's reported CPU read zero on every
+    /// sample even under load (stage-1 correction 6), so it must never gate
+    /// health. Memory/disk figures are correct.
+    pub async fn health(&self) -> Result<SandboxHealthReport, SandboxError> {
+        let fresh = Sandbox::get(&self.name)
+            .await
+            .map_err(|e| get_error(&self.name, e))?;
+        let phase = SandboxPhase::from(fresh.status_snapshot());
+        if !phase.is_running() {
+            return Err(SandboxError::NotRunning {
+                name: self.name.clone(),
+                phase,
+            });
+        }
+        let metrics = fresh
+            .metrics()
+            .await
+            .map_err(|source| operation_error(&self.name, "metrics", source))?;
+        Ok(SandboxHealthReport {
+            phase,
+            memory_used_bytes: metrics.memory_bytes,
+            memory_limit_bytes: metrics.memory_limit_bytes,
+            memory_available_bytes: metrics.memory_available_bytes,
+            writable_layer_used_bytes: metrics.upper_used_bytes,
+            writable_layer_free_bytes: metrics.upper_free_bytes,
+            uptime: metrics.uptime,
+        })
+    }
+
+    /// Rotate a source-ref secret on this sandbox, keeping the placeholder
+    /// stable.
+    ///
+    /// The patch re-asserts only the identity (`env`) and the host-side
+    /// source reference; the placeholder and allowed hosts are left
+    /// untouched, so the change classifies as `Rotated` and applies live when
+    /// the runtime advertises the `secrets_update` capability (stage-1 probe
+    /// `ci_msb_source_ref_secret_rotates_live`). The new value is resolved
+    /// from the host environment at apply time by the SDK.
+    ///
+    /// Egress/secret *structure* (adding a binding) is create-time only; this
+    /// path exists for value rotation of a binding the sandbox booted with.
+    pub async fn rotate_secret(
+        &self,
+        binding: &SecretBinding,
+    ) -> Result<SecretRotation, SandboxError> {
+        binding.validate_ref()?;
+
+
+        let plan = self
+            .sandbox
+            .modify()
+            .secret(|s| {
+                s.env(&binding.env_var).source(microsandbox::SecretSource::Env {
+                    var: binding.source_env_var.clone(),
+                })
+            })
+            .dry_run()
+            .await
+            .map_err(|source| operation_error(&self.name, "plan secret rotation", source))?;
+
+        if !plan.conflicts.is_empty() {
+            return Err(SandboxError::RotationConflict {
+                name: self.name.clone(),
+                env_var: binding.env_var.clone(),
+                details: plan
+                    .conflicts
+                    .iter()
+                    .map(|conflict| format!("{}: {}", conflict.field, conflict.message))
+                    .collect::<Vec<_>>()
+                    .join("; "),
+            });
+        }
+
+        let mut disposition = RotationDisposition::Live;
+        let mut saw_change = false;
+        for change in &plan.changes {
+            let PlannedChange::Secret(secret) = change else {
+                continue;
+            };
+            saw_change = true;
+            match secret.disposition {
+                ModificationDisposition::Live => {}
+                ModificationDisposition::NextStart => {
+                    if disposition == RotationDisposition::Live {
+                        disposition = RotationDisposition::NextStart;
+                    }
+                }
+                ModificationDisposition::RequiresRestart => {
+                    disposition = RotationDisposition::RequiresRestart;
+                }
+                _ => {
+                    return Err(SandboxError::RotationUnsupported {
+                        name: self.name.clone(),
+                        env_var: binding.env_var.clone(),
+                    });
+                }
+            }
+        }
+
+        let applied = self
+            .sandbox
+            .modify()
+            .secret(|s| {
+                s.env(&binding.env_var).source(microsandbox::SecretSource::Env {
+                    var: binding.source_env_var.clone(),
+                })
+            })
+            .apply()
+            .await
+            .map_err(|source| operation_error(&self.name, "rotate secret", source))?;
+
+        if saw_change && !applied.applied {
+            return Err(SandboxError::RotationNotApplied {
+                name: self.name.clone(),
+                env_var: binding.env_var.clone(),
+            });
+        }
+
+        Ok(SecretRotation {
+            disposition,
+            warnings: applied
+                .warnings
+                .iter()
+                .map(|warning| format!("{}: {}", warning.field, warning.message))
+                .collect(),
+        })
+    }
+
+    /// Wrap an fs future's error with sandbox context.
+    pub(crate) async fn fs_op<T>(
+        &self,
+        operation: &'static str,
+        future: impl Future<Output = microsandbox::MicrosandboxResult<T>>,
+    ) -> Result<T, SandboxError> {
+        future
+            .await
+            .map_err(|source| operation_error(&self.name, operation, source))
+    }
+
+    /// Map an exec-spawn/transport error: guest spawn failures are
+    /// command-level ([`SandboxError::ExecSpawn`]), everything else is a
+    /// backend operation error.
+    fn exec_error(
+        &self,
+        operation: &'static str,
+        cmd: &str,
+        source: MicrosandboxError,
+    ) -> SandboxError {
+        match source {
+            MicrosandboxError::ExecFailed(failed) => SandboxError::ExecSpawn {
+                name: self.name.clone(),
+                cmd: cmd.to_owned(),
+                message: failed.message,
+            },
+            source => operation_error(&self.name, operation, source),
+        }
+    }
+}
+
+/// A point-in-time health snapshot of a running sandbox.
+///
+/// See [`SandboxHandle::health`] — CPU is intentionally not reported.
+#[derive(Debug, Clone)]
+pub struct SandboxHealthReport {
+    /// Freshly read lifecycle phase (always `Running` on success).
+    pub phase: SandboxPhase,
+
+    /// Resident memory usage in bytes.
+    pub memory_used_bytes: u64,
+
+    /// Configured guest memory limit in bytes.
+    pub memory_limit_bytes: u64,
+
+    /// Guest-available memory in bytes when the guest reports it.
+    pub memory_available_bytes: Option<u64>,
+
+    /// Guest-visible writable-layer used bytes, when available.
+    pub writable_layer_used_bytes: Option<u64>,
+
+    /// Guest-visible writable-layer free bytes, when available.
+    pub writable_layer_free_bytes: Option<u64>,
+
+    /// Sandbox uptime at sampling time.
+    pub uptime: Duration,
+}
+
+/// Poll the runtime catalog until `name` is running, a terminal phase is
+/// observed, or the timeout expires with the last phase preserved.
+async fn wait_ready_by_name(name: &str, timeout: Duration) -> Result<(), SandboxError> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let handle = Sandbox::get(name).await.map_err(|e| get_error(name, e))?;
+        let phase = SandboxPhase::from(handle.status_snapshot());
+        match phase {
+            SandboxPhase::Running => return Ok(()),
+            SandboxPhase::Stopped | SandboxPhase::Crashed | SandboxPhase::Draining => {
+                return Err(SandboxError::TerminalBeforeReady {
+                    name: name.to_owned(),
+                    phase,
+                });
+            }
+            SandboxPhase::Created | SandboxPhase::Starting | SandboxPhase::Paused => {}
+        }
+        if Instant::now() >= deadline {
+            return Err(SandboxError::ReadinessTimeout {
+                name: name.to_owned(),
+                timeout,
+                last_phase: phase,
+            });
+        }
+        tokio::time::sleep(READINESS_POLL_INTERVAL).await;
+    }
+}
+
+/// Map a `Sandbox::get` failure: not-found is its own variant, everything
+/// else is a backend operation error.
+fn get_error(name: &str, source: MicrosandboxError) -> SandboxError {
+    match source {
+        MicrosandboxError::SandboxNotFound(_) => SandboxError::NotFound {
+            name: name.to_owned(),
+        },
+        source => operation_error(name, "get", source),
+    }
+}
+fn operation_error(
+    name: &str,
+    operation: &'static str,
+    source: MicrosandboxError,
+) -> SandboxError {
+    SandboxError::Operation {
+        name: name.to_owned(),
+        operation,
+        source: crate::error::SdkError(source),
+    }
+}

--- a/crates/right-sandbox/src/lib.rs
+++ b/crates/right-sandbox/src/lib.rs
@@ -1,11 +1,49 @@
 //! Agent Sandbox backend.
 //!
-//! Owns every microVM interaction: lifecycle, streaming execution, guest
-//! filesystem, Egress Mode, and Provider secret bindings. This is the only
-//! crate in the workspace that depends on the microsandbox SDK.
+//! Owns every microVM interaction: runtime install, sandbox lifecycle,
+//! streaming execution, guest filesystem, egress policy, and Provider secret
+//! bindings. This is the only crate in the workspace that depends on the
+//! microsandbox SDK; nothing in the public API exposes a raw SDK type.
 //!
-//! Stage 1 of the migration establishes only the pinned dependency and the
-//! live-microVM assumption probes in `tests/`. The API lands in stage 2.
+//! The entry points:
+//!
+//! - [`ensure_runtime_installed`] + [`diagnose_host`] — bot startup preflight.
+//! - [`sandbox_name`]/[`fit_sandbox_name`] — deterministic agent → sandbox
+//!   naming within the SDK's 128-byte name space.
+//! - [`SandboxSpec`] — everything a create needs, with Right's defaults.
+//! - [`SandboxHandle::create_or_attach`]/[`SandboxHandle::attach`] — the
+//!   unified handle replacing `resolved_sandbox` + `ssh_config_path`.
+//! - [`SandboxError`]/[`SandboxCause`] — the error taxonomy the supervisor
+//!   and Telegram UX match on.
+
+mod egress;
+mod error;
+mod exec;
+mod fs;
+mod handle;
+mod names;
+mod phase;
+mod resources;
+mod runtime;
+mod secrets;
+mod spec;
+
+pub use error::{SandboxCause, SandboxDiagnosis, SandboxError, SdkError};
+pub use exec::{
+    ChunkedStdin, ExecEvent, ExecOutcome, ExecRequest, ExecStream, PROTOCOL_FRAME_MAX_BYTES,
+    STDIN_CHUNK_BYTES, Stdin,
+};
+pub use fs::{FsEntryInfo, FsEntryKind};
+pub use handle::{DEFAULT_READY_TIMEOUT, SandboxHandle, SandboxHealthReport};
+pub use names::{MAX_SANDBOX_NAME_BYTES, fit_sandbox_name, sandbox_name};
+pub use phase::SandboxPhase;
+pub use resources::{DEFAULT_CPUS, DEFAULT_MEMORY_MIB, DEFAULT_WRITABLE_LAYER_MIB, Resources};
+pub use runtime::{diagnose_host, ensure_runtime_installed};
+pub use secrets::{
+    RotationDisposition, SecretBinding, SecretRotation, TLS_BYPASS_HOSTS, default_placeholder,
+    tls_bypass_list,
+};
+pub use spec::SandboxSpec;
 
 /// The exact microsandbox SDK version this crate is built against.
 ///

--- a/crates/right-sandbox/src/lib.rs
+++ b/crates/right-sandbox/src/lib.rs
@@ -28,6 +28,7 @@ mod runtime;
 mod secrets;
 mod spec;
 
+pub use egress::Egress;
 pub use error::{SandboxCause, SandboxDiagnosis, SandboxError, SdkError};
 pub use exec::{
     ChunkedStdin, ExecEvent, ExecOutcome, ExecRequest, ExecStream, PROTOCOL_FRAME_MAX_BYTES,
@@ -51,3 +52,22 @@ pub use spec::SandboxSpec;
 /// separate version floor. Bumping this constant is a deliberate act that
 /// requires the `ci_msb_` contract suite to pass first.
 pub const PINNED_SDK_VERSION: &str = "0.6.10";
+
+#[cfg(test)]
+mod api_surface_tests {
+    //! Compile-time guard that the types behind public fields and methods are
+    //! themselves nameable outside the crate. A `pub` type in a private module
+    //! that is never re-exported compiles silently (no rustc warning) while
+    //! being unusable downstream — this test names each such type so the
+    //! omission becomes a compile error here, not a confusing failure in
+    //! stage 4.
+
+    #[test]
+    fn public_field_types_are_exported() {
+        // `SandboxSpec::egress` is a public field; `Egress` must be nameable.
+        fn _assert(_: Option<crate::Egress>) {}
+        // `SandboxSpec::resources` and `secrets` element types.
+        fn _assert2(_: Option<crate::Resources>, _: Option<crate::SecretBinding>) {}
+        let _ = (_assert, _assert2);
+    }
+}

--- a/crates/right-sandbox/src/names.rs
+++ b/crates/right-sandbox/src/names.rs
@@ -1,0 +1,201 @@
+//! Sandbox naming.
+//!
+//! The SDK accepts names of 1..=128 bytes over `[A-Za-z0-9._-]` with an
+//! alphanumeric first byte (`microsandbox::sandbox::validate_sandbox_name`).
+//! [`fit_sandbox_name`] maps an arbitrary agent name into that space,
+//! deterministically, and is total: every output passes the SDK validator.
+
+use sha2::{Digest, Sha256};
+
+/// Maximum sandbox-name length in bytes, re-exported from the pinned SDK so
+/// the cap can never drift from the validator that enforces it.
+pub const MAX_SANDBOX_NAME_BYTES: usize = microsandbox::MAX_SANDBOX_NAME_BYTES;
+
+/// Hex characters of the SHA-256 of the raw name appended on truncation.
+const FIT_HASH_HEX_CHARS: usize = 8;
+
+/// Byte budget for the human-readable prefix when truncation is required:
+/// prefix + `-` + hash must fit [`MAX_SANDBOX_NAME_BYTES`].
+const FIT_PREFIX_MAX_BYTES: usize = MAX_SANDBOX_NAME_BYTES - 1 - FIT_HASH_HEX_CHARS;
+
+/// Generate the deterministic sandbox name for an agent.
+///
+/// Returns `right-{agent_name}`, fitted via [`fit_sandbox_name`] when the
+/// agent name is not already a valid SDK sandbox name.
+pub fn sandbox_name(agent_name: &str) -> String {
+    fit_sandbox_name(&format!("right-{agent_name}"))
+}
+
+/// Fit `raw` into the SDK's sandbox-name space.
+///
+/// Returns `raw` unchanged when it already validates. Otherwise invalid
+/// characters collapse to a single `-` run, leading non-alphanumerics are
+/// dropped, and an over-long result becomes `{prefix}-{hash8}` where `hash8`
+/// is the first 8 lowercase hex chars of the SHA-256 of the full `raw` string
+/// — the hash keeps names with long common prefixes distinct and is
+/// deterministic across processes. When nothing valid survives sanitizing,
+/// the name is `sandbox-{hash8}`.
+///
+/// Invariant: the output always passes
+/// `microsandbox::sandbox::validate_sandbox_name`.
+pub fn fit_sandbox_name(raw: &str) -> String {
+    if microsandbox::sandbox::validate_sandbox_name(raw).is_ok() {
+        return raw.to_owned();
+    }
+    let sanitized = sanitize_name(raw);
+    if sanitized.is_empty() {
+        return format!("sandbox-{}", name_hash(raw));
+    }
+    if sanitized.len() <= MAX_SANDBOX_NAME_BYTES {
+        return sanitized;
+    }
+    // Truncate on a char boundary at or under the prefix budget, then strip
+    // trailing separators so the hash join never produces a ragged name. The
+    // sanitizer's leading-alnum rule guarantees the prefix stays non-empty.
+    let boundary = sanitized
+        .char_indices()
+        .map(|(index, _)| index)
+        .take_while(|&index| index <= FIT_PREFIX_MAX_BYTES)
+        .last()
+        .unwrap_or(0);
+    let prefix = sanitized[..boundary].trim_end_matches(['-', '.', '_']);
+    format!("{prefix}-{}", name_hash(raw))
+}
+
+/// Map every character outside `[A-Za-z0-9._-]` into a single `-` run and
+/// drop everything before the first alphanumeric (the SDK requires an
+/// alphanumeric first byte). Interior separators and case are preserved.
+fn sanitize_name(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut last_dash = false;
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch);
+            last_dash = false;
+        } else if out.is_empty() {
+            // Leading separators and invalid chars: the name must start
+            // alphanumeric.
+        } else if ch == '.' || ch == '_' {
+            out.push(ch);
+            last_dash = false;
+        } else if !last_dash {
+            // '-' and every invalid char collapse to one dash.
+            out.push('-');
+            last_dash = true;
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    out
+}
+
+/// First [`FIT_HASH_HEX_CHARS`] lowercase hex chars of the SHA-256 of `raw`.
+fn name_hash(raw: &str) -> String {
+    let digest = Sha256::digest(raw.as_bytes());
+    let mut out = String::with_capacity(FIT_HASH_HEX_CHARS);
+    for byte in &digest[..FIT_HASH_HEX_CHARS / 2] {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_valid(name: &str) {
+        microsandbox::sandbox::validate_sandbox_name(name)
+            .unwrap_or_else(|err| panic!("fitted name {name:?} must validate: {err}"));
+        assert!(
+            name.len() <= MAX_SANDBOX_NAME_BYTES,
+            "fitted name {name:?} exceeds {MAX_SANDBOX_NAME_BYTES} bytes"
+        );
+    }
+
+    #[test]
+    fn valid_names_pass_through_unchanged() {
+        for name in ["right-a", "a", "right-Agent_1.2"] {
+            assert_eq!(fit_sandbox_name(name), name);
+        }
+        let max_len = "x".repeat(MAX_SANDBOX_NAME_BYTES);
+        assert_eq!(fit_sandbox_name(&max_len), max_len);
+    }
+
+    #[test]
+    fn invalid_characters_collapse_to_single_dash_runs() {
+        assert_eq!(fit_sandbox_name("my agent!!"), "my-agent");
+        assert_eq!(fit_sandbox_name("a  --  b"), "a-b");
+        assert_eq!(fit_sandbox_name("spaces\tand\nnewlines"), "spaces-and-newlines");
+    }
+
+    #[test]
+    fn leading_non_alphanumerics_are_dropped() {
+        assert_eq!(fit_sandbox_name("-oops"), "oops");
+        assert_eq!(fit_sandbox_name("!!lead"), "lead");
+        assert_eq!(fit_sandbox_name(".dot"), "dot");
+        assert_eq!(fit_sandbox_name("_under"), "under");
+    }
+
+    #[test]
+    fn all_invalid_input_falls_back_to_a_hashed_name() {
+        let fitted = fit_sandbox_name("!!!");
+        assert!(fitted.starts_with("sandbox-"), "got {fitted:?}");
+        assert_valid(&fitted);
+    }
+
+    #[test]
+    fn empty_input_falls_back_to_a_hashed_name() {
+        let fitted = fit_sandbox_name("");
+        assert!(fitted.starts_with("sandbox-"), "got {fitted:?}");
+        assert_valid(&fitted);
+    }
+
+    #[test]
+    fn long_names_truncate_with_a_stable_hash() {
+        let raw = format!("right-{}", "a".repeat(200));
+        let fitted = fit_sandbox_name(&raw);
+        assert_eq!(fitted.len(), MAX_SANDBOX_NAME_BYTES);
+        assert!(fitted.ends_with(&format!("-{}", name_hash(&raw))));
+        assert_valid(&fitted);
+        // Deterministic across calls.
+        assert_eq!(fit_sandbox_name(&raw), fitted);
+    }
+
+    #[test]
+    fn truncation_lands_on_a_char_boundary() {
+        // A multibyte char straddling the prefix budget must snap back to the
+        // boundary before it, so the multibyte char is dropped whole.
+        let mut raw = "x".repeat(FIT_PREFIX_MAX_BYTES - 1);
+        raw.push('é');
+        raw.push_str(&"y".repeat(50));
+        let fitted = fit_sandbox_name(&raw);
+        assert_valid(&fitted);
+        assert!(!fitted.contains('é'));
+        assert!(fitted.starts_with(&"x".repeat(FIT_PREFIX_MAX_BYTES - 1)));
+    }
+
+    #[test]
+    fn long_names_with_common_prefixes_stay_distinct() {
+        let prefix = "shared-prefix-".repeat(8);
+        let a = fit_sandbox_name(&format!("{prefix}-agent-one"));
+        let b = fit_sandbox_name(&format!("{prefix}-agent-two"));
+        assert_ne!(a, b);
+        assert_valid(&a);
+        assert_valid(&b);
+    }
+
+    #[test]
+    fn fitting_is_idempotent() {
+        for raw in ["right-a", "my agent!!", &"z".repeat(300), "!!!", ""] {
+            let once = fit_sandbox_name(raw);
+            assert_eq!(fit_sandbox_name(&once), once, "fit must be idempotent");
+        }
+    }
+
+    #[test]
+    fn sandbox_name_prefixes_right() {
+        assert_eq!(sandbox_name("hal"), "right-hal");
+        assert_valid(&sandbox_name("An Agent With Spaces"));
+    }
+}

--- a/crates/right-sandbox/src/phase.rs
+++ b/crates/right-sandbox/src/phase.rs
@@ -1,0 +1,112 @@
+//! Lifecycle phase of an Agent Sandbox.
+//!
+//! Mirrors the SDK's `SandboxStatus` without leaking it into the public API:
+//! the phase set is a stable contract for the supervisor, while the SDK enum
+//! stays free to change under a pinned-version bump.
+
+use std::fmt;
+
+use microsandbox::sandbox::SandboxStatus;
+
+/// Lifecycle phase of an Agent Sandbox.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SandboxPhase {
+    /// Recorded in the runtime catalog but never booted.
+    Created,
+
+    /// Boot in progress.
+    Starting,
+
+    /// Booted and serving the agent bridge.
+    Running,
+
+    /// Graceful shutdown in progress.
+    Draining,
+
+    /// Suspended.
+    Paused,
+
+    /// Cleanly stopped. Terminal.
+    Stopped,
+
+    /// Exited unexpectedly. Terminal.
+    Crashed,
+}
+
+impl SandboxPhase {
+    /// Whether the sandbox is serving exec/fs traffic.
+    pub fn is_running(self) -> bool {
+        matches!(self, Self::Running)
+    }
+
+    /// Whether the phase is terminal (mirrors the SDK's `Stopped | Crashed`
+    /// terminal predicate).
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Stopped | Self::Crashed)
+    }
+}
+
+impl From<SandboxStatus> for SandboxPhase {
+    fn from(status: SandboxStatus) -> Self {
+        match status {
+            SandboxStatus::Created => Self::Created,
+            SandboxStatus::Starting => Self::Starting,
+            SandboxStatus::Running => Self::Running,
+            SandboxStatus::Draining => Self::Draining,
+            SandboxStatus::Paused => Self::Paused,
+            SandboxStatus::Stopped => Self::Stopped,
+            SandboxStatus::Crashed => Self::Crashed,
+        }
+    }
+}
+
+impl fmt::Display for SandboxPhase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Self::Created => "created",
+            Self::Starting => "starting",
+            Self::Running => "running",
+            Self::Draining => "draining",
+            Self::Paused => "paused",
+            Self::Stopped => "stopped",
+            Self::Crashed => "crashed",
+        };
+        f.write_str(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_sdk_status_maps_to_a_phase() {
+        let statuses = [
+            (SandboxStatus::Created, SandboxPhase::Created),
+            (SandboxStatus::Starting, SandboxPhase::Starting),
+            (SandboxStatus::Running, SandboxPhase::Running),
+            (SandboxStatus::Draining, SandboxPhase::Draining),
+            (SandboxStatus::Paused, SandboxPhase::Paused),
+            (SandboxStatus::Stopped, SandboxPhase::Stopped),
+            (SandboxStatus::Crashed, SandboxPhase::Crashed),
+        ];
+        for (status, phase) in statuses {
+            assert_eq!(SandboxPhase::from(status), phase);
+        }
+    }
+
+    #[test]
+    fn terminal_matches_upstream_predicate() {
+        assert!(SandboxPhase::Stopped.is_terminal());
+        assert!(SandboxPhase::Crashed.is_terminal());
+        for phase in [
+            SandboxPhase::Created,
+            SandboxPhase::Starting,
+            SandboxPhase::Running,
+            SandboxPhase::Draining,
+            SandboxPhase::Paused,
+        ] {
+            assert!(!phase.is_terminal(), "{phase} must not be terminal");
+        }
+    }
+}

--- a/crates/right-sandbox/src/resources.rs
+++ b/crates/right-sandbox/src/resources.rs
@@ -1,0 +1,107 @@
+//! Resource sizing for an Agent Sandbox.
+//!
+//! The SDK's own defaults are 1 vCPU / 512 MiB / a 4 GiB writable layer —
+//! far too small for a Claude Code agent, and the 4 GiB default layer boots
+//! measurably slower than an explicit 16 GiB one (stage-1 verdict 7). Right
+//! therefore always sets its own defaults explicitly. Memory is a *limit*,
+//! not a reservation: the host only commits what the guest touches.
+
+use crate::error::SandboxError;
+
+/// Default vCPU count per Agent Sandbox.
+pub const DEFAULT_CPUS: u8 = 2;
+
+/// Default memory limit per Agent Sandbox, in MiB (8 GiB).
+pub const DEFAULT_MEMORY_MIB: u32 = 8 * 1024;
+
+/// Default writable-layer size per Agent Sandbox, in MiB (16 GiB).
+pub const DEFAULT_WRITABLE_LAYER_MIB: u32 = 16 * 1024;
+
+/// Per-agent resource sizing (`sandbox.resources` in the agent config).
+///
+/// The defaults are Right's, applied at create; every field is overridable
+/// per agent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Resources {
+    /// vCPU count.
+    pub cpus: u8,
+
+    /// Memory limit in MiB.
+    pub memory_mib: u32,
+
+    /// Writable-layer (guest rootfs upper) size in MiB.
+    pub writable_layer_mib: u32,
+}
+
+impl Default for Resources {
+    fn default() -> Self {
+        Self {
+            cpus: DEFAULT_CPUS,
+            memory_mib: DEFAULT_MEMORY_MIB,
+            writable_layer_mib: DEFAULT_WRITABLE_LAYER_MIB,
+        }
+    }
+}
+
+impl Resources {
+    /// Reject zero-sized resources before they reach the runtime.
+    pub(crate) fn validate(&self) -> Result<(), SandboxError> {
+        if self.cpus == 0 {
+            return Err(SandboxError::InvalidSpec {
+                field: "resources.cpus",
+                reason: "must be at least 1".to_owned(),
+            });
+        }
+        if self.memory_mib == 0 {
+            return Err(SandboxError::InvalidSpec {
+                field: "resources.memory_mib",
+                reason: "must be at least 1".to_owned(),
+            });
+        }
+        if self.writable_layer_mib == 0 {
+            return Err(SandboxError::InvalidSpec {
+                field: "resources.writable_layer_mib",
+                reason: "must be at least 1".to_owned(),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_rights_own_not_the_sdks() {
+        let resources = Resources::default();
+        assert_eq!(resources.cpus, 2);
+        assert_eq!(resources.memory_mib, 8192);
+        assert_eq!(resources.writable_layer_mib, 16384);
+    }
+
+    #[test]
+    fn zero_sized_resources_are_rejected() {
+        for resources in [
+            Resources {
+                cpus: 0,
+                ..Resources::default()
+            },
+            Resources {
+                memory_mib: 0,
+                ..Resources::default()
+            },
+            Resources {
+                writable_layer_mib: 0,
+                ..Resources::default()
+            },
+        ] {
+            assert!(resources.validate().is_err(), "{resources:?} must fail");
+        }
+    }
+
+    #[test]
+    fn default_resources_validate() {
+        Resources::default().validate().expect("defaults are valid");
+    }
+}

--- a/crates/right-sandbox/src/runtime.rs
+++ b/crates/right-sandbox/src/runtime.rs
@@ -64,17 +64,18 @@ pub fn diagnose_host() -> Result<(), SandboxError> {
 
 /// The actual install path, run at most once per process unless it fails.
 async fn install_once() -> Result<(), SandboxError> {
-    if setup::is_installed() {
-        return Ok(());
-    }
-    let _lock = acquire_install_lock()?;
-    // A process that held the lock before us may have completed the install.
+    // Take the cross-process lock unconditionally on this cold path. The
+    // OnceCell guards the hot path; here a concurrent process may have a
+    // half-extracted install (the SDK's install is not atomic), and the
+    // sentinel files can be present before extraction/chmod finish — so the
+    // is_installed() check must run under the lock, never before it.
+    let _lock = acquire_install_lock().await?;
     if setup::is_installed() {
         return Ok(());
     }
     tracing::info!("installing pinned microsandbox runtime into ~/.microsandbox");
     setup::install().await.map_err(|source| SandboxError::RuntimeInstall {
-        source: crate::error::SdkError(source),
+        source: Box::new(crate::error::SdkError(source)),
     })?;
     if !setup::is_installed() {
         return Err(SandboxError::RuntimeInstallVerify);
@@ -83,12 +84,13 @@ async fn install_once() -> Result<(), SandboxError> {
     Ok(())
 }
 
-/// Take the host-global advisory install lock, blocking until free.
+/// Take the host-global advisory install lock, waiting until free.
 ///
 /// The kernel releases the lock if the holder dies mid-install; the next
 /// process re-checks `is_installed()` under the lock, so a partial install is
-/// always completed by someone.
-fn acquire_install_lock() -> Result<InstallLock, SandboxError> {
+/// always completed by someone. The wait is async so a concurrent install
+/// never blocks a tokio worker thread for the full download.
+async fn acquire_install_lock() -> Result<InstallLock, SandboxError> {
     let path = std::env::temp_dir().join(format!("{INSTALL_LOCK_KEY}.lock"));
     let file = std::fs::OpenOptions::new()
         .create(true)
@@ -103,7 +105,7 @@ fn acquire_install_lock() -> Result<InstallLock, SandboxError> {
         match file.try_lock() {
             Ok(()) => return Ok(InstallLock { _file: file }),
             Err(std::fs::TryLockError::WouldBlock) => {
-                std::thread::sleep(INSTALL_LOCK_RETRY);
+                tokio::time::sleep(INSTALL_LOCK_RETRY).await;
             }
             Err(std::fs::TryLockError::Error(source)) => {
                 return Err(SandboxError::RuntimeInstallLock { path, source });
@@ -111,6 +113,7 @@ fn acquire_install_lock() -> Result<InstallLock, SandboxError> {
         }
     }
 }
+
 
 /// The held advisory lock; drop releases it.
 struct InstallLock {
@@ -129,9 +132,9 @@ mod tests {
         assert_eq!(INSTALL_LOCK_KEY, "rt-msb-runtime-install");
     }
 
-    #[test]
-    fn install_lock_can_be_taken() {
-        let lock = acquire_install_lock().expect("install lock");
+    #[tokio::test]
+    async fn install_lock_can_be_taken() {
+        let lock = acquire_install_lock().await.expect("install lock");
         drop(lock);
     }
 

--- a/crates/right-sandbox/src/runtime.rs
+++ b/crates/right-sandbox/src/runtime.rs
@@ -1,0 +1,143 @@
+//! Runtime installation and host preflight.
+//!
+//! Right has no user-visible install step and no PATH dependency: the pinned
+//! `msb`/`libkrunfw` runtime is downloaded and verified into `~/.microsandbox`
+//! by the SDK's `setup` module on first use.
+
+use std::time::Duration;
+
+use microsandbox::setup;
+use tokio::sync::OnceCell;
+
+use crate::error::SandboxError;
+
+/// Install-once cell: success is cached for the process; failure is not, so
+/// the next caller retries (mirrors the stage-1 probe helper).
+static RUNTIME_INSTALL: OnceCell<()> = OnceCell::const_new();
+
+/// Name of the cross-process advisory install lock under `$TMPDIR`. Stable:
+/// every Right process on the host, from any worktree, must share one lock.
+const INSTALL_LOCK_KEY: &str = "rt-msb-runtime-install";
+
+/// Backoff between attempts to take the install lock.
+const INSTALL_LOCK_RETRY: Duration = Duration::from_millis(200);
+
+/// Ensure the SDK's pinned `msb`/`libkrunfw` runtime is installed.
+///
+/// `setup::is_installed()` is a file-presence check, so the fast path costs
+/// two `stat` calls. The download itself is guarded by a cross-process
+/// advisory lock: several Right processes (bots, CLI, test binaries from
+/// sibling worktrees) may hit a first-run install concurrently, and the
+/// install directory is host-global.
+pub async fn ensure_runtime_installed() -> Result<(), SandboxError> {
+    RUNTIME_INSTALL.get_or_try_init(install_once).await?;
+    Ok(())
+}
+
+/// Preflight the host's ability to run microVMs.
+///
+/// Returns `Err(SandboxError::HypervisorUnavailable)` when the SDK's
+/// diagnosis reports blocking problems (no hypervisor, `/dev/kvm` missing or
+/// unreadable, unsupported platform). The bot's startup calls this after
+/// [`ensure_runtime_installed`] so a hypervisor-less host gets a clear
+/// message instead of an opaque boot failure.
+pub fn diagnose_host() -> Result<(), SandboxError> {
+    let diagnosis = setup::diagnose();
+    if diagnosis.is_healthy() {
+        return Ok(());
+    }
+    let mut summary = Vec::with_capacity(diagnosis.problems.len());
+    let mut fixes = Vec::new();
+    for problem in &diagnosis.problems {
+        summary.push(problem.headline.clone());
+        if let Some(fix) = &problem.fix {
+            fixes.push(fix.description.clone());
+            fixes.extend(
+                fix.commands
+                    .iter()
+                    .map(|command| format!("{} {}", command.program, command.args.join(" "))),
+            );
+        }
+    }
+    Err(SandboxError::HypervisorUnavailable { summary: summary.join("; "), fixes })
+}
+
+/// The actual install path, run at most once per process unless it fails.
+async fn install_once() -> Result<(), SandboxError> {
+    if setup::is_installed() {
+        return Ok(());
+    }
+    let _lock = acquire_install_lock()?;
+    // A process that held the lock before us may have completed the install.
+    if setup::is_installed() {
+        return Ok(());
+    }
+    tracing::info!("installing pinned microsandbox runtime into ~/.microsandbox");
+    setup::install().await.map_err(|source| SandboxError::RuntimeInstall {
+        source: crate::error::SdkError(source),
+    })?;
+    if !setup::is_installed() {
+        return Err(SandboxError::RuntimeInstallVerify);
+    }
+    tracing::info!("microsandbox runtime installed");
+    Ok(())
+}
+
+/// Take the host-global advisory install lock, blocking until free.
+///
+/// The kernel releases the lock if the holder dies mid-install; the next
+/// process re-checks `is_installed()` under the lock, so a partial install is
+/// always completed by someone.
+fn acquire_install_lock() -> Result<InstallLock, SandboxError> {
+    let path = std::env::temp_dir().join(format!("{INSTALL_LOCK_KEY}.lock"));
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(&path)
+        .map_err(|source| SandboxError::RuntimeInstallLock {
+            path: path.clone(),
+            source,
+        })?;
+    loop {
+        match file.try_lock() {
+            Ok(()) => return Ok(InstallLock { _file: file }),
+            Err(std::fs::TryLockError::WouldBlock) => {
+                std::thread::sleep(INSTALL_LOCK_RETRY);
+            }
+            Err(std::fs::TryLockError::Error(source)) => {
+                return Err(SandboxError::RuntimeInstallLock { path, source });
+            }
+        }
+    }
+}
+
+/// The held advisory lock; drop releases it.
+struct InstallLock {
+    _file: std::fs::File,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::SandboxCause;
+
+    #[test]
+    fn install_lock_key_is_stable() {
+        // The lock must be host-global across worktrees and runs: changing
+        // the key splits the lock set and re-admits concurrent installs.
+        assert_eq!(INSTALL_LOCK_KEY, "rt-msb-runtime-install");
+    }
+
+    #[test]
+    fn install_lock_can_be_taken() {
+        let lock = acquire_install_lock().expect("install lock");
+        drop(lock);
+    }
+
+    #[test]
+    fn install_errors_surface_the_runtime_install_cause() {
+        let err = SandboxError::RuntimeInstallVerify;
+        assert_eq!(err.cause(), Some(SandboxCause::RuntimeInstallFailed));
+    }
+}

--- a/crates/right-sandbox/src/secrets.rs
+++ b/crates/right-sandbox/src/secrets.rs
@@ -1,0 +1,326 @@
+//! Provider secret bindings: source-ref secrets over TLS interception.
+//!
+//! A [`SecretBinding`] never carries a credential value. It names the
+//! guest-visible environment variable (which holds the *placeholder*), the
+//! host-side environment variable the value is resolved from at spawn/apply
+//! time, and the hosts allowed to receive the real value. The SDK persists
+//! only the placeholder and the source reference — no secret material at
+//! rest.
+//!
+//! TLS interception follows ADR-0003: it is a **bypass deny-list**. Adding
+//! any secret enables interception for every destination on the intercepted
+//! ports except the bypass list. [`TLS_BYPASS_HOSTS`] always carries the
+//! Anthropic hosts so the agent's primary path is never intercepted and needs
+//! no guest CA configuration.
+
+use microsandbox::SecretSource;
+use microsandbox::sandbox::SecretBuilder;
+
+use crate::error::SandboxError;
+
+/// Hosts that are never TLS-intercepted: the Anthropic API paths Claude Code
+/// talks to. Maintained, security-relevant inventory (ADR-0003) — review on
+/// change.
+pub const TLS_BYPASS_HOSTS: &[&str] = &["api.anthropic.com", "*.anthropic.com"];
+
+/// The full TLS bypass list: Anthropic hosts plus caller-supplied extras,
+/// deduplicated, order-preserved.
+pub fn tls_bypass_list(extra: &[String]) -> Vec<String> {
+    let mut list: Vec<String> = TLS_BYPASS_HOSTS.iter().map(|host| (*host).to_owned()).collect();
+    for host in extra {
+        if !list.contains(host) {
+            list.push(host.clone());
+        }
+    }
+    list
+}
+
+/// The placeholder the guest sees for `env_var` when none is set explicitly.
+///
+/// Matches the SDK's own default (`$MSB_<ENV_VAR>`) so a binding that never
+/// sets a placeholder explicitly still names a stable string.
+pub fn default_placeholder(env_var: &str) -> String {
+    format!("$MSB_{env_var}")
+}
+
+/// A provider credential binding.
+///
+/// Carries *references* only. The value is resolved from the host
+/// environment variable named by `source_env_var` at sandbox spawn and at
+/// rotation apply; it never enters this struct, the sandbox's durable config,
+/// or the guest (the guest sees `placeholder`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecretBinding {
+    /// Guest-visible environment variable; holds the placeholder.
+    pub env_var: String,
+
+    /// Host environment variable the real value is resolved from.
+    pub source_env_var: String,
+
+    /// Stable placeholder string the guest sees. Survives rotation.
+    pub placeholder: String,
+
+    /// Hosts allowed to receive the substituted value. Exact hosts
+    /// (`"api.example.com"`) or suffix wildcards (`"*.example.com"`).
+    pub allowed_hosts: Vec<String>,
+
+    /// Opt in to query-parameter substitution (headers and basic-auth are on
+    /// by default; body injection is never enabled).
+    pub inject_query: bool,
+}
+
+impl SecretBinding {
+    /// A binding with the SDK-default placeholder and no allowed hosts.
+    pub fn new(env_var: impl Into<String>, source_env_var: impl Into<String>) -> Self {
+        let env_var = env_var.into();
+        Self {
+            placeholder: default_placeholder(&env_var),
+            env_var,
+            source_env_var: source_env_var.into(),
+            allowed_hosts: Vec::new(),
+            inject_query: false,
+        }
+    }
+
+    /// Validate the binding. Placeholder rules mirror the SDK's: non-empty,
+    /// at most 1024 bytes, no NUL/CR/LF.
+    pub(crate) fn validate(&self) -> Result<(), SandboxError> {
+        /// SDK placeholder cap (`MAX_SECRET_PLACEHOLDER_BYTES`).
+        const MAX_PLACEHOLDER_BYTES: usize = 1024;
+
+        if self.env_var.is_empty() || self.env_var.contains(['=', '\0']) {
+            return Err(SandboxError::InvalidSpec {
+                field: "secrets.env_var",
+                reason: "must be non-empty and contain no '=' or NUL".to_owned(),
+            });
+        }
+        if self.source_env_var.is_empty() {
+            return Err(SandboxError::InvalidSpec {
+                field: "secrets.source_env_var",
+                reason: "must be non-empty".to_owned(),
+            });
+        }
+        if self.placeholder.is_empty()
+            || self.placeholder.len() > MAX_PLACEHOLDER_BYTES
+            || self.placeholder.contains(['\0', '\r', '\n'])
+        {
+            return Err(SandboxError::InvalidSpec {
+                field: "secrets.placeholder",
+                reason: format!(
+                    "must be non-empty, at most {MAX_PLACEHOLDER_BYTES} bytes, and contain no NUL/CR/LF"
+                ),
+            });
+        }
+        if self.allowed_hosts.is_empty() {
+            return Err(SandboxError::InvalidSpec {
+                field: "secrets.allowed_hosts",
+                reason: "a secret with no allowed hosts can never be substituted".to_owned(),
+            });
+        }
+        for host in &self.allowed_hosts {
+            let suffix = host.strip_prefix("*.");
+            if host.is_empty() || suffix.is_some_and(str::is_empty) {
+                return Err(SandboxError::InvalidSpec {
+                    field: "secrets.allowed_hosts",
+                    reason: format!("invalid host pattern {host:?}"),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate only the identity half of the binding (rotation needs no
+    /// hosts or placeholder — those are deliberately left untouched so the
+    /// placeholder stays stable and the change classifies as `Rotated`).
+    pub(crate) fn validate_ref(&self) -> Result<(), SandboxError> {
+        if self.env_var.is_empty() || self.env_var.contains(['=', '\0']) {
+            return Err(SandboxError::InvalidSpec {
+                field: "secrets.env_var",
+                reason: "must be non-empty and contain no '=' or NUL".to_owned(),
+            });
+        }
+        if self.source_env_var.is_empty() {
+            return Err(SandboxError::InvalidSpec {
+                field: "secrets.source_env_var",
+                reason: "must be non-empty".to_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Build the SDK secret builder. The value is a source reference; nothing
+    /// secret is constructed here.
+    pub(crate) fn sdk_builder(&self) -> SecretBuilder {
+        let mut builder = SecretBuilder::new()
+            .env(&self.env_var)
+            .source(SecretSource::Env {
+                var: self.source_env_var.clone(),
+            })
+            .placeholder(&self.placeholder);
+        for host in &self.allowed_hosts {
+            builder = if host.starts_with("*.") {
+                builder.allow_host_pattern(host)
+            } else {
+                builder.allow_host(host)
+            };
+        }
+        if self.inject_query {
+            builder = builder.inject_query(true);
+        }
+        builder
+    }
+}
+
+/// How a secret rotation takes effect, mirroring the SDK's modification
+/// disposition for the secret change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RotationDisposition {
+    /// Applied to the running sandbox without a restart (the runtime
+    /// advertised the `secrets_update` control capability).
+    Live,
+
+    /// Persisted; takes effect the next time the sandbox starts.
+    NextStart,
+
+    /// The change requires a restart, which `apply()` performs.
+    RequiresRestart,
+}
+
+/// The outcome of a secret rotation on a sandbox.
+#[derive(Debug, Clone)]
+pub struct SecretRotation {
+    /// How the rotation took effect.
+    pub disposition: RotationDisposition,
+
+    /// Non-fatal planner/apply warnings, rendered as `field: message`.
+    pub warnings: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use microsandbox::HostPattern;
+
+    use super::*;
+
+    fn valid_binding() -> SecretBinding {
+        let mut binding = SecretBinding::new("KEY", "HOST_KEY");
+        binding.allowed_hosts = vec!["api.example.com".to_owned()];
+        binding
+    }
+
+    #[test]
+    fn anthropic_hosts_are_always_bypassed() {
+        let list = tls_bypass_list(&[]);
+        assert!(list.contains(&"api.anthropic.com".to_owned()));
+        assert!(list.contains(&"*.anthropic.com".to_owned()));
+    }
+
+    #[test]
+    fn bypass_list_appends_extras_without_duplicates() {
+        let list = tls_bypass_list(&[
+            "internal.corp".to_owned(),
+            "api.anthropic.com".to_owned(),
+        ]);
+        assert_eq!(
+            list,
+            ["api.anthropic.com", "*.anthropic.com", "internal.corp"],
+            "base hosts first, extras appended, duplicates dropped: {list:?}"
+        );
+    }
+
+    #[test]
+    fn default_placeholder_matches_the_sdk_shape() {
+        assert_eq!(
+            default_placeholder("RIGHT_PROVIDER_KEY"),
+            "$MSB_RIGHT_PROVIDER_KEY"
+        );
+    }
+
+    #[test]
+    fn binding_translation_carries_only_references() {
+        let mut binding = SecretBinding::new("RIGHT_PROVIDER_KEY", "HOST_KEY_VAR");
+        binding.allowed_hosts = vec!["api.example.com".to_owned(), "*.example.org".to_owned()];
+        let entry = binding.sdk_builder().build();
+
+        assert_eq!(entry.env_var, "RIGHT_PROVIDER_KEY");
+        assert!(
+            entry.value.is_empty(),
+            "a source-ref binding must never carry a value"
+        );
+        assert_eq!(
+            entry.source,
+            Some(SecretSource::Env {
+                var: "HOST_KEY_VAR".to_owned()
+            })
+        );
+        assert_eq!(entry.placeholder, "$MSB_RIGHT_PROVIDER_KEY");
+        assert_eq!(
+            entry.allowed_hosts,
+            [
+                HostPattern::Exact("api.example.com".to_owned()),
+                HostPattern::Wildcard("*.example.org".to_owned()),
+            ]
+        );
+        assert!(entry.injection.headers, "headers inject by default");
+        assert!(!entry.injection.query_params, "query params are opt-in");
+        assert!(!entry.injection.body, "body injection is never enabled");
+    }
+
+    #[test]
+    fn explicit_placeholder_overrides_the_default() {
+        let mut binding = valid_binding();
+        binding.placeholder = "stable-placeholder".to_owned();
+        let entry = binding.sdk_builder().build();
+        assert_eq!(entry.placeholder, "stable-placeholder");
+    }
+
+    #[test]
+    fn query_injection_is_opt_in() {
+        let mut binding = valid_binding();
+        binding.inject_query = true;
+        assert!(binding.sdk_builder().build().injection.query_params);
+    }
+
+    #[test]
+    fn invalid_bindings_are_rejected() {
+        let binding = valid_binding();
+        assert!(binding.validate().is_ok(), "a complete binding validates");
+
+        let mut empty_hosts = binding.clone();
+        empty_hosts.allowed_hosts = Vec::new();
+        assert!(empty_hosts.validate().is_err(), "no allowed hosts");
+
+        let mut empty_env = binding.clone();
+        empty_env.env_var = String::new();
+        assert!(empty_env.validate().is_err(), "empty env var");
+
+        let mut eq_env = binding.clone();
+        eq_env.env_var = "A=B".to_owned();
+        assert!(eq_env.validate().is_err(), "'=' in env var");
+
+        let mut empty_source = binding.clone();
+        empty_source.source_env_var = String::new();
+        assert!(empty_source.validate().is_err(), "empty source env var");
+
+        for placeholder in ["", "with\nnewline", "with\rcr", "with\0nul"] {
+            let mut bad = binding.clone();
+            bad.placeholder = placeholder.to_owned();
+            assert!(bad.validate().is_err(), "placeholder {placeholder:?}");
+        }
+
+        let mut long = binding.clone();
+        long.placeholder = "x".repeat(1025);
+        assert!(long.validate().is_err(), "placeholder over 1024 bytes");
+
+        let mut bad_host = binding.clone();
+        bad_host.allowed_hosts = vec!["*.".to_owned()];
+        assert!(bad_host.validate().is_err(), "wildcard with empty suffix");
+    }
+
+    #[test]
+    fn rotation_refs_need_only_the_identity_half() {
+        let minimal = SecretBinding::new("KEY", "HOST_KEY");
+        assert!(minimal.validate_ref().is_ok());
+        assert!(minimal.validate().is_err(), "no hosts: not creatable");
+    }
+}

--- a/crates/right-sandbox/src/spec.rs
+++ b/crates/right-sandbox/src/spec.rs
@@ -1,0 +1,232 @@
+//! Declarative sandbox specification.
+//!
+//! [`SandboxSpec`] is everything create needs: name, image, resources,
+//! egress, secret bindings, TLS bypass extras, and guest defaults. It
+//! validates before any SDK call and compiles into an SDK builder in
+//! [`SandboxSpec::to_builder`].
+
+use microsandbox::Sandbox;
+use microsandbox::sandbox::SandboxBuilder;
+
+use crate::egress::Egress;
+use crate::error::SandboxError;
+use crate::resources::Resources;
+use crate::secrets::{SecretBinding, tls_bypass_list};
+
+/// Everything needed to create an Agent Sandbox.
+///
+/// `SandboxSpec::new` starts from Right's defaults (permissive egress,
+/// [`Resources::default`], no secrets); callers override fields directly.
+/// Validation is explicit: [`SandboxHandle::create_or_attach`](crate::SandboxHandle::create_or_attach)
+/// validates, and `validate` is public so config-load paths can fail early.
+#[derive(Debug, Clone)]
+pub struct SandboxSpec {
+    /// Sandbox name. Must pass the SDK's name validation; use
+    /// [`crate::sandbox_name`]/[`crate::fit_sandbox_name`] to derive one from
+    /// an agent name.
+    pub name: String,
+
+    /// OCI image reference (e.g. `"node:22-slim"`).
+    pub image: String,
+
+    /// vCPU / memory / writable-layer sizing.
+    pub resources: Resources,
+
+    /// Egress policy. Create-time only — the SDK cannot change network policy
+    /// on a running sandbox.
+    pub egress: Egress,
+
+    /// Provider credential bindings (source references only).
+    pub secrets: Vec<SecretBinding>,
+
+    /// Extra TLS-bypass hosts on top of [`crate::TLS_BYPASS_HOSTS`]. Only
+    /// consulted when at least one secret is bound (no secrets means
+    /// interception is off entirely).
+    pub tls_bypass_extra: Vec<String>,
+
+    /// Default guest working directory.
+    pub workdir: Option<String>,
+
+    /// Guest shell used by `shell` execs (default: the image's `/bin/sh`).
+    pub shell: Option<String>,
+
+    /// Extra guest environment variables. The `MSB_` prefix is reserved by
+    /// the SDK and rejected.
+    pub env: Vec<(String, String)>,
+
+    /// Sandbox-wide guest user (`"1000"`, `"sandbox"`, `"1000:1000"`).
+    /// Absent means root; Right's provisioning sets this to the unprivileged
+    /// `sandbox` user.
+    pub user: Option<String>,
+}
+
+impl SandboxSpec {
+    /// A spec with Right's defaults for the given name and image.
+    pub fn new(name: impl Into<String>, image: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            image: image.into(),
+            resources: Resources::default(),
+            egress: Egress::default(),
+            secrets: Vec::new(),
+            tls_bypass_extra: Vec::new(),
+            workdir: None,
+            shell: None,
+            env: Vec::new(),
+            user: None,
+        }
+    }
+
+    /// Validate every field before any SDK call.
+    pub fn validate(&self) -> Result<(), SandboxError> {
+        if self.image.trim().is_empty() {
+            return Err(SandboxError::InvalidSpec {
+                field: "image",
+                reason: "must be a non-empty OCI image reference".to_owned(),
+            });
+        }
+        microsandbox::sandbox::validate_sandbox_name(&self.name).map_err(|err| {
+            SandboxError::InvalidSpec {
+                field: "name",
+                reason: format!("{err}"),
+            }
+        })?;
+        self.resources.validate()?;
+        self.egress.validate()?;
+        let mut seen_env_vars: Vec<&str> = Vec::with_capacity(self.secrets.len());
+        for binding in &self.secrets {
+            binding.validate()?;
+            if seen_env_vars.contains(&binding.env_var.as_str()) {
+                return Err(SandboxError::InvalidSpec {
+                    field: "secrets",
+                    reason: format!("duplicate guest env var {:?}", binding.env_var),
+                });
+            }
+            seen_env_vars.push(&binding.env_var);
+        }
+        for (key, _) in &self.env {
+            if key.is_empty() || key.contains(['=', '\0']) {
+                return Err(SandboxError::InvalidSpec {
+                    field: "env",
+                    reason: "keys must be non-empty and contain no '=' or NUL".to_owned(),
+                });
+            }
+            if key.starts_with("MSB_") {
+                return Err(SandboxError::InvalidSpec {
+                    field: "env",
+                    reason: format!("key {key:?} uses the SDK-reserved MSB_ prefix"),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Compile into an SDK builder.
+    ///
+    /// Ordering matters: `.network()` is applied before `.secret_entry(..)`
+    /// because the latter also enables TLS interception as a side effect; the
+    /// explicit `tls(|t| t.enabled(!secrets.is_empty()))` keeps interception
+    /// deterministic regardless of SDK defaults.
+    pub(crate) fn to_builder(&self) -> Result<SandboxBuilder, SandboxError> {
+        self.validate()?;
+
+        let policy = self.egress.to_policy()?;
+        let interception = !self.secrets.is_empty();
+        let bypass = tls_bypass_list(&self.tls_bypass_extra);
+
+        let mut builder = Sandbox::builder(&self.name)
+            .image(self.image.as_str())
+            .cpus(self.resources.cpus)
+            .memory(self.resources.memory_mib)
+            .root_disk(self.resources.writable_layer_mib)
+            .detached(true)
+            .network(|network| {
+                network.policy(policy).tls(|tls| {
+                    let mut tls = tls.enabled(interception);
+                    for host in &bypass {
+                        tls = tls.bypass(host);
+                    }
+                    tls
+                })
+            });
+        if let Some(workdir) = &self.workdir {
+            builder = builder.workdir(workdir);
+        }
+        if let Some(shell) = &self.shell {
+            builder = builder.shell(shell);
+        }
+        if let Some(user) = &self.user {
+            builder = builder.user(user);
+        }
+        for (key, value) in &self.env {
+            builder = builder.env(key, value);
+        }
+        for binding in &self.secrets {
+            builder = builder.secret_entry(binding.sdk_builder().build());
+        }
+        Ok(builder)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::names::sandbox_name;
+
+    #[test]
+    fn default_spec_validates() {
+        let spec = SandboxSpec::new(sandbox_name("hal"), "node:22-slim");
+        spec.validate().expect("default spec is valid");
+    }
+
+    #[test]
+    fn invalid_names_are_rejected() {
+        for name in ["", "-lead", "has space", &"x".repeat(129)] {
+            let spec = SandboxSpec::new(name, "node:22-slim");
+            let err = spec.validate().expect_err("invalid name must fail");
+            assert!(
+                matches!(err, SandboxError::InvalidSpec { field: "name", .. }),
+                "{name:?}: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_image_is_rejected() {
+        let spec = SandboxSpec::new("right-a", "  ");
+        assert!(spec.validate().is_err());
+    }
+
+    #[test]
+    fn msb_prefixed_env_is_rejected() {
+        let mut spec = SandboxSpec::new("right-a", "node:22-slim");
+        spec.env.push(("MSB_HOME".to_owned(), "/tmp/x".to_owned()));
+        let err = spec.validate().expect_err("MSB_ env must fail");
+        assert!(matches!(err, SandboxError::InvalidSpec { field: "env", .. }));
+    }
+
+    #[test]
+    fn duplicate_secret_env_vars_are_rejected() {
+        let mut spec = SandboxSpec::new("right-a", "node:22-slim");
+        for source in ["HOST_KEY_A", "HOST_KEY_B"] {
+            let mut binding = SecretBinding::new("KEY", source);
+            binding.allowed_hosts = vec!["api.example.com".to_owned()];
+            spec.secrets.push(binding);
+        }
+        let err = spec.validate().expect_err("duplicate secret env vars must fail");
+        assert!(matches!(err, SandboxError::InvalidSpec { field: "secrets", .. }));
+    }
+
+    #[test]
+    fn spec_with_secrets_and_restrictive_egress_validates() {
+        let mut spec = SandboxSpec::new(sandbox_name("hal"), "node:22-slim");
+        spec.egress = Egress::Restrictive {
+            allow: vec!["example.com".to_owned()],
+        };
+        let mut binding = SecretBinding::new("KEY", "HOST_KEY");
+        binding.allowed_hosts = vec!["api.example.com".to_owned()];
+        spec.secrets = vec![binding];
+        spec.user = Some("sandbox".to_owned());
+        spec.validate().expect("full spec is valid");
+    }
+}


### PR DESCRIPTION
Stage 2 of the microsandbox migration (#172). Turns the stage-1 shell crate `crates/right-sandbox` into the production sandbox backend API that stages 3-4 consume.

Stacked on #173 (stage 1). Review only commits `msb/01-assumptions..HEAD`.

## What lands
- `ensure_runtime_installed` + `diagnose_host` preflight (no PATH dep, pinned `msb`/`libkrunfw` into `~/.microsandbox`, cross-process install lock).
- `SandboxCause` error taxonomy replacing `GatewayCause` (thiserror, FAIL FAST), plus `SandboxDiagnosis` for the operator-facing UX.
- `SandboxHandle`: unified create-or-attach-by-name, lifecycle, error-phase-terminal readiness preserving last status. No SSH anywhere.
- `exec_stream` with `ChunkedStdin` (64 KiB chunks under the 4 MiB protocol frame cap, const-asserted).
- Guest filesystem via the SDK fs API (no host bind mounts); platform-tree parent stays root-owned.
- Typed `Egress` (Permissive / Restrictive+allowlist) → SDK `NetworkPolicy`; replaces `policy.yaml` codegen.
- Source-ref secret bindings (env-var name persisted, value resolved at spawn), stable placeholder across live rotation, Anthropic hosts on the TLS bypass deny-list.
- `Resources` 2 vCPU / 8 GiB / 16 GiB writable layer defaults, set explicitly. Health never gates on CPU.

## Verification
- `cargo nextest run -p right-sandbox`: 48 passed, 15 skipped (ci_msb_ probes compile).
- `cargo check --workspace`: green.
- `cargo clippy -p right-sandbox --tests`: 0 warnings.

## Review
Dedicated `review-rust-code` pass on `msb/01-assumptions..HEAD` returned REQUEST-CHANGES; every finding is resolved in `3e2cb9c3` + `28f51843`:
- **Blocking**: `Egress` was the type of public field `SandboxSpec::egress` but never re-exported → exported + compile-time api-surface guard test.
- Exec error context preserved (`ExecSpawn` kind + errno/stage; `{:#}` chains); new `ExecLost` variant correctly classifies mid-session drops as backend health.
- `rotate_secret` gate ordering fixed so an unknown secret reports `RotationTargetMissing` instead of the misleading downstream conflict; dead `RotationNotApplied` removed.
- Install lock is async + taken unconditionally on the cold path (no half-install fast-path race).
- `SdkError` boxed → `result_large_err` cleared.

No raw `microsandbox` types leak in the public API. No real credential values anywhere.