### PR TITLE
feat(migrate): right agent migrate-sandbox (stage 5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5920,6 +5920,7 @@ dependencies = [
 name = "right-agent"
 version = "0.4.2"
 dependencies = [
+ "anyhow",
  "chrono",
  "const_format",
  "cron",

--- a/crates/bot/src/config_watcher.rs
+++ b/crates/bot/src/config_watcher.rs
@@ -467,8 +467,8 @@ learning:
 
     #[tokio::test]
     async fn diff_providers_only_is_providers_reload() {
-        let old = "restart: never\nmax_restarts: 5\nsandbox:\n  mode: openshell\n";
-        let new = "restart: never\nmax_restarts: 5\nsandbox:\n  mode: openshell\n  providers:\n    - name: right-typefully\n      type: generic\n      generic:\n        env_var: TYPEFULLY_API_KEY\n        upstream_host: api.typefully.com\n";
+        let old = "restart: never\nmax_restarts: 5\nsandbox:\n  name: right-alpha\n";
+        let new = "restart: never\nmax_restarts: 5\nsandbox:\n  name: right-alpha\n  providers:\n    - name: right-typefully\n      type: generic\n      generic:\n        env_var: TYPEFULLY_API_KEY\n        upstream_host: api.typefully.com\n";
         match classify(old, new) {
             ChangeKind::ProvidersReload { new_config, .. } => {
                 let provs = new_config
@@ -486,8 +486,8 @@ learning:
 
     #[tokio::test]
     async fn diff_providers_plus_other_field_is_restart_required() {
-        let old = "restart: never\nmax_restarts: 5\nsandbox:\n  mode: openshell\n";
-        let new = "restart: always\nmax_restarts: 5\nsandbox:\n  mode: openshell\n  providers:\n    - name: right-typefully\n      type: generic\n      generic:\n        env_var: TYPEFULLY_API_KEY\n        upstream_host: api.typefully.com\n";
+        let old = "restart: never\nmax_restarts: 5\nsandbox:\n  name: right-alpha\n";
+        let new = "restart: always\nmax_restarts: 5\nsandbox:\n  name: right-alpha\n  providers:\n    - name: right-typefully\n      type: generic\n      generic:\n        env_var: TYPEFULLY_API_KEY\n        upstream_host: api.typefully.com\n";
         assert!(matches!(classify(old, new), ChangeKind::RestartRequired));
     }
 

--- a/crates/right-agent-config/src/lib.rs
+++ b/crates/right-agent-config/src/lib.rs
@@ -227,6 +227,17 @@ const SANDBOXLESS_REMOVED: &str = "`sandbox.mode: none` is no longer supported �
 Run `right agent migrate-sandbox <agent>` to move this agent's host files into a sandbox, \
 then delete the `mode:` line from agent.yaml.";
 
+/// Rejection message for an agent that still lives in an OpenShell sandbox.
+/// Emitted verbatim when an agent.yaml still carries `sandbox: mode: openshell`
+/// — the marker every pre-microsandbox `right agent init` wrote and only
+/// `right agent migrate-sandbox` removes. Starting such an agent would attach
+/// it to an *empty* microsandbox VM while its real home still sits in the
+/// OpenShell sandbox, so it must fail before anything runs. Public so the CLI
+/// can assert the command it advertises actually exists.
+pub const OPENSHELL_UNMIGRATED: &str = "`sandbox.mode: openshell` means this agent's files still live in an OpenShell sandbox, which Right no longer runs. \
+Run `right agent migrate-sandbox <agent>` to move them into a microsandbox VM — it rewrites this agent.yaml for you. \
+Until then the agent cannot start: attaching it to a fresh sandbox would hand it an empty home.";
+
 /// Provider type slug. Built-in slugs are validated against the OpenShell
 /// profile catalog at API boundaries; `claude` is rejected by Right (see
 /// `crates/right/src/internal_api.rs`).
@@ -342,10 +353,12 @@ pub struct SandboxConfig {
 }
 
 /// Wire shape of `sandbox:`. It still carries the two retired keys so an
-/// agent.yaml written before the microsandbox migration keeps loading: `mode`
-/// is accepted and ignored (except `none`, which is rejected outright — see
-/// [`SANDBOXLESS_REMOVED`]) and `policy_file` is inert now that OpenShell
-/// policy files are gone. Both keys are dropped one release from now.
+/// agent.yaml written before the microsandbox migration keeps *loading* far
+/// enough to be diagnosed: every `mode:` value is now rejected — `none` as
+/// removed sandboxless mode ([`SANDBOXLESS_REMOVED`]), `openshell` as an
+/// unmigrated agent ([`OPENSHELL_UNMIGRATED`]) — and `policy_file` is inert
+/// now that OpenShell policy files are gone. Both keys are dropped one release
+/// from now.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct SandboxConfigRaw {
@@ -364,8 +377,9 @@ impl TryFrom<SandboxConfigRaw> for SandboxConfig {
 
     fn try_from(raw: SandboxConfigRaw) -> Result<Self, Self::Error> {
         match raw.mode.as_deref() {
-            None | Some("openshell") => {}
+            None => {}
             Some("none") => return Err(SANDBOXLESS_REMOVED.to_owned()),
+            Some("openshell") => return Err(OPENSHELL_UNMIGRATED.to_owned()),
             Some(other) => {
                 return Err(format!(
                     "invalid sandbox mode: '{other}'. The `mode:` key is retired; delete it."
@@ -857,12 +871,21 @@ mod tests {
     }
 
     #[test]
-    fn sandbox_mode_openshell_is_accepted_and_ignored() {
-        let config: AgentConfig =
-            serde_saphyr::from_str("sandbox:\n  mode: openshell\n  name: right-alpha\n").unwrap();
+    fn sandbox_mode_openshell_is_rejected_as_unmigrated() {
+        let error = serde_saphyr::from_str::<AgentConfig>(
+            "sandbox:\n  mode: openshell\n  name: right-alpha\n",
+        )
+        .unwrap_err();
 
-        let sandbox = config.sandbox.expect("sandbox section");
-        assert_eq!(sandbox.name.as_deref(), Some("right-alpha"));
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("still live in an OpenShell sandbox"),
+            "unexpected error: {rendered}"
+        );
+        assert!(
+            rendered.contains("right agent migrate-sandbox"),
+            "error must name the migration command: {rendered}"
+        );
     }
 
     #[test]
@@ -974,7 +997,7 @@ prefilter_enabled: false
 
     #[test]
     fn sandbox_providers_parses_built_in_entry() {
-        let yaml = "sandbox:\n  mode: openshell\n  providers:\n    - name: foo-anthropic\n      type: anthropic\n";
+        let yaml = "sandbox:\n  providers:\n    - name: foo-anthropic\n      type: anthropic\n";
         let cfg: AgentConfig = serde_saphyr::from_str(yaml).unwrap();
         let sandbox = cfg.sandbox.unwrap();
         assert_eq!(sandbox.providers.len(), 1);
@@ -987,7 +1010,7 @@ prefilter_enabled: false
 
     #[test]
     fn sandbox_providers_parses_generic_entry() {
-        let yaml = "sandbox:\n  mode: openshell\n  providers:\n    - name: foo-acme\n      type: generic\n      label: acme\n      generic:\n        env_var: ACME_TOKEN\n        header_name: X-Acme-Token\n        upstream_host: api.acme.com\n        upstream_path_prefix: /v1\n";
+        let yaml = "sandbox:\n  providers:\n    - name: foo-acme\n      type: generic\n      label: acme\n      generic:\n        env_var: ACME_TOKEN\n        header_name: X-Acme-Token\n        upstream_host: api.acme.com\n        upstream_path_prefix: /v1\n";
         let cfg: AgentConfig = serde_saphyr::from_str(yaml).unwrap();
         let entry = &cfg.sandbox.unwrap().providers[0];
         assert_eq!(entry.type_, ProviderType::Generic);
@@ -1060,7 +1083,7 @@ prefilter_enabled: false
 
     #[test]
     fn sandbox_providers_defaults_to_empty() {
-        let yaml = "sandbox: { mode: openshell }";
+        let yaml = "sandbox: { name: right-alpha }";
         let cfg: AgentConfig = serde_saphyr::from_str(yaml).unwrap();
         assert!(cfg.sandbox.unwrap().providers.is_empty());
     }

--- a/crates/right-agent/Cargo.toml
+++ b/crates/right-agent/Cargo.toml
@@ -44,6 +44,8 @@ test-support = ["right-openshell/test-support"]
 [dev-dependencies]
 right-openshell = { path = "../right-openshell", version = "*", features = ["test-support"] }
 right-db = { path = "../right-db", version = "*", features = ["test-support"] }
+anyhow = { workspace = true }
+tempfile = "3.27"
 rustls = { workspace = true }
 tokio = { version = "1.52", features = ["test-util"] }
 wiremock = "0.6"

--- a/crates/right-agent/Cargo.toml
+++ b/crates/right-agent/Cargo.toml
@@ -45,7 +45,6 @@ test-support = ["right-openshell/test-support"]
 right-openshell = { path = "../right-openshell", version = "*", features = ["test-support"] }
 right-db = { path = "../right-db", version = "*", features = ["test-support"] }
 anyhow = { workspace = true }
-tempfile = "3.27"
 rustls = { workspace = true }
 tokio = { version = "1.52", features = ["test-util"] }
 wiremock = "0.6"

--- a/crates/right-agent/src/agent/types.rs
+++ b/crates/right-agent/src/agent/types.rs
@@ -343,16 +343,30 @@ attachments:
     }
 
     #[test]
-    fn sandbox_config_accepts_retired_mode_and_policy_keys() {
+    fn sandbox_config_accepts_retired_policy_file_key() {
         let yaml = r#"
 sandbox:
-  mode: openshell
   policy_file: policy.yaml
   name: right-alpha
 "#;
         let config: AgentConfig = serde_saphyr::from_str(yaml).unwrap();
         let sandbox = config.sandbox.unwrap();
         assert_eq!(sandbox.name.as_deref(), Some("right-alpha"));
+    }
+
+    #[test]
+    fn sandbox_config_rejects_mode_openshell() {
+        let yaml = r#"
+sandbox:
+  mode: openshell
+  policy_file: policy.yaml
+  name: right-alpha
+"#;
+        let error = serde_saphyr::from_str::<AgentConfig>(yaml).unwrap_err();
+        assert!(
+            format!("{error:#}").contains("right agent migrate-sandbox"),
+            "an unmigrated agent must be told how to migrate: {error:#}"
+        );
     }
 
     #[test]
@@ -402,10 +416,9 @@ sandbox:
     }
 
     #[test]
-    fn agent_config_without_sandbox_defaults_mode_openshell() {
+    fn agent_config_without_sandbox_section_parses() {
         let yaml = "{}";
         let config: AgentConfig = serde_saphyr::from_str(yaml).unwrap();
-        // sandbox is None — effective mode should be openshell (tested via helper)
         assert!(config.sandbox.is_none());
     }
 
@@ -413,7 +426,6 @@ sandbox:
     fn sandbox_config_with_name() {
         let yaml = r#"
 sandbox:
-  mode: openshell
   policy_file: policy.yaml
   name: "rightclaw-brain-20260415-1430"
 "#;
@@ -426,7 +438,6 @@ sandbox:
     fn sandbox_config_without_name_is_none() {
         let yaml = r#"
 sandbox:
-  mode: openshell
   policy_file: policy.yaml
 "#;
         let config: AgentConfig = serde_saphyr::from_str(yaml).unwrap();

--- a/crates/right-agent/src/lib.rs
+++ b/crates/right-agent/src/lib.rs
@@ -11,6 +11,7 @@ pub mod learned_skills;
 pub mod rebootstrap;
 pub mod runtime;
 pub mod sandbox_backup;
+pub mod sandbox_migrate;
 pub(crate) mod tunnel;
 pub mod usage;
 

--- a/crates/right-agent/src/sandbox_migrate.rs
+++ b/crates/right-agent/src/sandbox_migrate.rs
@@ -1,0 +1,279 @@
+//! Guest-side half of `right agent migrate-sandbox`: unpack an agent's
+//! OpenShell home into a microsandbox VM and prove it landed.
+//!
+//! The CLI owns the OpenShell side (archive, `agent.yaml` rewrite, deleting the
+//! old sandbox); everything that touches the *new* sandbox lives here, beside
+//! [`crate::sandbox_backup`], so it can be exercised against a real microVM.
+//!
+//! Nothing in this module is destructive: it only ever writes into the new
+//! sandbox. The migration's one destructive step runs in the CLI, after
+//! [`verify_restore`] returns `Ok`.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::time::Duration;
+
+use right_sandbox::{ExecRequest, GUEST_HOME, GUEST_USER, SandboxHandle};
+
+/// Guest-home-relative paths left out of the migration archive.
+///
+/// The rebuildable caches are the same set `right agent backup` skips
+/// (`right_openshell::openshell::DEFAULT_REBUILDABLE_BACKUP_EXCLUDES`); `.ssh`
+/// holds the OpenShell SSH transport's keys and `known_hosts`, which mean
+/// nothing to a microVM that has no SSH at all. Everything else is agent data
+/// and is carried verbatim.
+pub const MIGRATION_EXCLUDES: &[&str] = &[".cache", ".venv", ".npm", ".uv", ".ssh"];
+
+/// The one carried entry that stays root-owned after the restore.
+///
+/// `.platform` is the platform-owned tree the agent must not be able to
+/// rewrite (provisioning `chmod a-w`s it); handing it to the guest user would
+/// undo exactly that.
+const PLATFORM_ENTRY: &str = ".platform";
+
+/// Guest path the migration archive is staged at before extraction. Removed as
+/// soon as `tar` has read it, so the migrated sandbox carries no copy of its
+/// own archive.
+const MIGRATE_TAR_GUEST_PATH: &str = "/tmp/right-migrate.tar.gz";
+
+/// How long the in-guest extraction may take before it is killed.
+const EXTRACT_TIMEOUT: Duration = Duration::from_secs(900);
+
+/// How long the recursive ownership hand-over may take.
+const OWNERSHIP_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// How long a verification probe may take.
+const VERIFY_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// The top-level entries the archive actually carried.
+///
+/// `listing` is the source sandbox's `ls -A /sandbox` output; anything named by
+/// [`MIGRATION_EXCLUDES`] was left out of the archive and must not be expected
+/// on the other side. Nested excludes (`.claude/settings.json`) never match a
+/// top-level name, so their parent stays required.
+pub fn carried_entries(listing: &str, excludes: &[&str]) -> Vec<String> {
+    listing
+        .lines()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .filter(|name| !excludes.contains(name))
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Basename of a guest path, so a listing can be compared by entry name
+/// whether the SDK reports `"/sandbox/.claude"` or `".claude"`.
+pub fn entry_name(path: &str) -> &str {
+    path.trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .unwrap_or(path)
+}
+
+/// Entries the source had that the restored sandbox does not.
+pub fn missing_entries<'a>(expected: &'a [String], present: &HashSet<&str>) -> Vec<&'a str> {
+    expected
+        .iter()
+        .map(String::as_str)
+        .filter(|name| !present.contains(name))
+        .collect()
+}
+
+/// Run a guest command and fail with its stderr when it exits non-zero.
+async fn run_checked(
+    sandbox: &SandboxHandle,
+    request: &ExecRequest,
+    what: &str,
+) -> miette::Result<String> {
+    let outcome = sandbox
+        .exec(request)
+        .await
+        .map_err(|error| miette::miette!("{what}: {error:#}"))?;
+    if !outcome.success() {
+        return Err(miette::miette!(
+            "{what} exited with {}: {}",
+            outcome.code,
+            String::from_utf8_lossy(&outcome.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&outcome.stdout).into_owned())
+}
+
+/// Unpack the migration archive over the new sandbox's guest home.
+///
+/// `--no-same-owner` is the uid remap: the archive carries the OpenShell
+/// guest's numeric uids, which mean something else (or nothing) in this image,
+/// so extraction normalizes everything to root and
+/// [`hand_home_to_guest_user`] then hands it to the guest user by name.
+pub async fn restore_archive(sandbox: &SandboxHandle, archive: &Path) -> miette::Result<()> {
+    sandbox
+        .fs_copy_from_host(archive, MIGRATE_TAR_GUEST_PATH)
+        .await
+        .map_err(|error| {
+            miette::miette!(
+                "upload {} into the new sandbox: {error:#}",
+                archive.display()
+            )
+        })?;
+
+    let extract = ExecRequest {
+        cmd: "tar".to_owned(),
+        args: vec![
+            "xzpf".to_owned(),
+            MIGRATE_TAR_GUEST_PATH.to_owned(),
+            "-C".to_owned(),
+            GUEST_HOME.to_owned(),
+            "--strip-components=1".to_owned(),
+            "--no-same-owner".to_owned(),
+            "sandbox".to_owned(),
+        ],
+        user: Some("0".to_owned()),
+        timeout: Some(EXTRACT_TIMEOUT),
+        ..ExecRequest::default()
+    };
+    run_checked(sandbox, &extract, "extract the migration archive").await?;
+
+    sandbox
+        .fs_remove(MIGRATE_TAR_GUEST_PATH)
+        .await
+        .map_err(|error| miette::miette!("remove the staged migration archive: {error:#}"))
+}
+
+/// Give every carried top-level entry except `.platform` to the guest user.
+///
+/// Returns whether the hand-over happened: the unprivileged guest user is
+/// created by sandbox provisioning, and a sandbox that has not been provisioned
+/// yet has no such user. Leaving the files root-owned is then the correct
+/// outcome (provisioning owns that step), and the caller reports it rather than
+/// pretending the ownership is what it is not.
+pub async fn hand_home_to_guest_user(sandbox: &SandboxHandle) -> miette::Result<bool> {
+    let probe = ExecRequest {
+        cmd: "id".to_owned(),
+        args: vec!["-u".to_owned(), GUEST_USER.to_owned()],
+        user: Some("0".to_owned()),
+        timeout: Some(VERIFY_TIMEOUT),
+        ..ExecRequest::default()
+    };
+    let probe_outcome = sandbox
+        .exec(&probe)
+        .await
+        .map_err(|error| miette::miette!("probe for the '{GUEST_USER}' guest user: {error:#}"))?;
+    if !probe_outcome.success() {
+        tracing::warn!(
+            user = GUEST_USER,
+            "guest user does not exist yet; migrated files stay root-owned until provisioning creates it"
+        );
+        return Ok(false);
+    }
+
+    let chown = ExecRequest {
+        cmd: "find".to_owned(),
+        args: vec![
+            GUEST_HOME.to_owned(),
+            "-mindepth".to_owned(),
+            "1".to_owned(),
+            "-maxdepth".to_owned(),
+            "1".to_owned(),
+            "!".to_owned(),
+            "-name".to_owned(),
+            PLATFORM_ENTRY.to_owned(),
+            "-exec".to_owned(),
+            "chown".to_owned(),
+            "-R".to_owned(),
+            GUEST_USER.to_owned(),
+            "{}".to_owned(),
+            "+".to_owned(),
+        ],
+        user: Some("0".to_owned()),
+        timeout: Some(OWNERSHIP_TIMEOUT),
+        ..ExecRequest::default()
+    };
+    run_checked(sandbox, &chown, "hand the migrated home to the guest user").await?;
+    Ok(true)
+}
+
+/// Prove the restore landed before anything destructive runs.
+///
+/// Checks the three things a silent tar failure would break: every top-level
+/// entry the source had is present, the home holds actual bytes, and — when the
+/// hand-over ran — nothing outside `.platform` is still root-owned.
+pub async fn verify_restore(
+    sandbox: &SandboxHandle,
+    expected: &[String],
+    handed_to_guest: bool,
+) -> miette::Result<()> {
+    let entries = sandbox
+        .fs_list(GUEST_HOME)
+        .await
+        .map_err(|error| miette::miette!("list the migrated guest home: {error:#}"))?;
+    let present: HashSet<&str> = entries
+        .iter()
+        .map(|entry| entry_name(&entry.path))
+        .collect();
+    let missing = missing_entries(expected, &present);
+    if !missing.is_empty() {
+        return Err(miette::miette!(
+            "the migrated sandbox is missing {} of {} entries the OpenShell sandbox had: {}",
+            missing.len(),
+            expected.len(),
+            missing.join(", ")
+        ));
+    }
+
+    let du = ExecRequest {
+        cmd: "du".to_owned(),
+        args: vec!["-s".to_owned(), "-k".to_owned(), GUEST_HOME.to_owned()],
+        user: Some("0".to_owned()),
+        timeout: Some(VERIFY_TIMEOUT),
+        ..ExecRequest::default()
+    };
+    let du_out = run_checked(sandbox, &du, "measure the migrated guest home").await?;
+    let kib: u64 = du_out
+        .split_whitespace()
+        .next()
+        .and_then(|field| field.parse().ok())
+        .ok_or_else(|| miette::miette!("could not read `du` output: {}", du_out.trim()))?;
+    if kib == 0 {
+        return Err(miette::miette!(
+            "the migrated guest home is empty after extraction"
+        ));
+    }
+
+    if handed_to_guest {
+        let stray = ExecRequest {
+            cmd: "find".to_owned(),
+            args: vec![
+                GUEST_HOME.to_owned(),
+                "-mindepth".to_owned(),
+                "1".to_owned(),
+                "-maxdepth".to_owned(),
+                "1".to_owned(),
+                "!".to_owned(),
+                "-name".to_owned(),
+                PLATFORM_ENTRY.to_owned(),
+                "!".to_owned(),
+                "-user".to_owned(),
+                GUEST_USER.to_owned(),
+                "-print".to_owned(),
+            ],
+            user: Some("0".to_owned()),
+            timeout: Some(VERIFY_TIMEOUT),
+            ..ExecRequest::default()
+        };
+        let stray_out = run_checked(sandbox, &stray, "check migrated ownership").await?;
+        if !stray_out.trim().is_empty() {
+            return Err(miette::miette!(
+                "these migrated entries are not owned by '{GUEST_USER}': {}",
+                stray_out.split_whitespace().collect::<Vec<_>>().join(", ")
+            ));
+        }
+    }
+
+    tracing::info!(
+        entries = expected.len(),
+        kib,
+        handed_to_guest,
+        "migration verified"
+    );
+    Ok(())
+}

--- a/crates/right-agent/tests/ci_msb_migrate_restore.rs
+++ b/crates/right-agent/tests/ci_msb_migrate_restore.rs
@@ -1,0 +1,207 @@
+//! Live-microVM cover for the guest side of `right agent migrate-sandbox`:
+//! the archive an OpenShell sandbox produces really does unpack into a fresh
+//! Agent Sandbox, and the verification that gates the destructive step really
+//! does fail when it should.
+//!
+//! The archive here is built exactly the way
+//! `right_openshell::openshell::ssh_tar_download` builds it — members rooted at
+//! `sandbox/`, foreign numeric uids — so the extraction flags are under test,
+//! not a hand-tailored fixture.
+
+use anyhow::{Context, Result};
+use right_agent::sandbox_migrate::{
+    MIGRATION_EXCLUDES, carried_entries, hand_home_to_guest_user, restore_archive, verify_restore,
+};
+use right_sandbox::{
+    DEFAULT_READY_TIMEOUT, DEFAULT_SANDBOX_IMAGE, ExecRequest, GUEST_HOME, SandboxHandle,
+    SandboxSpec, ensure_runtime_installed, fit_sandbox_name,
+};
+
+/// Top-level entries the fake OpenShell home holds. `.cache` is excluded from
+/// the archive; `.platform` must survive as root-owned.
+const SOURCE_LISTING: &str = ".platform\n.claude\n.cache\nCLAUDE.md\nprojects\n";
+
+/// Uid the archive claims for every member: a foreign id from the OpenShell
+/// guest that must not survive into the new sandbox.
+const FOREIGN_UID: &str = "1234";
+
+/// Deletes the sandbox even when the test panics mid-assertion.
+struct SandboxGuard(String);
+
+impl Drop for SandboxGuard {
+    fn drop(&mut self) {
+        let name = self.0.clone();
+        std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("cleanup runtime");
+            if let Err(error) = runtime.block_on(SandboxHandle::delete(&name)) {
+                eprintln!("cleanup: deleting {name} failed: {error:#}");
+            }
+        })
+        .join()
+        .expect("cleanup thread");
+    }
+}
+
+fn sandbox_name(label: &str) -> String {
+    let runid =
+        std::env::var("RIGHT_TEST_RUN_ID").unwrap_or_else(|_| std::process::id().to_string());
+    fit_sandbox_name(&format!("rt-msbmig-{label}-{runid}"))
+}
+
+async fn boot(name: &str) -> Result<SandboxHandle> {
+    let mut spec = SandboxSpec::new(name, DEFAULT_SANDBOX_IMAGE);
+    spec.workdir = Some(GUEST_HOME.to_owned());
+    let sandbox = SandboxHandle::create_or_attach(&spec)
+        .await
+        .context("create sandbox")?;
+    sandbox
+        .wait_ready(DEFAULT_READY_TIMEOUT)
+        .await
+        .context("wait ready")?;
+    Ok(sandbox)
+}
+
+async fn sh(sandbox: &SandboxHandle, script: &str) -> Result<(i32, String)> {
+    let request = ExecRequest {
+        cmd: "sh".to_owned(),
+        args: vec!["-c".to_owned(), script.to_owned()],
+        user: Some("0".to_owned()),
+        timeout: Some(std::time::Duration::from_secs(120)),
+        ..ExecRequest::default()
+    };
+    let outcome = sandbox.exec(&request).await.context("exec")?;
+    Ok((
+        outcome.code,
+        String::from_utf8_lossy(&outcome.stdout).into_owned(),
+    ))
+}
+
+/// Build the archive an OpenShell sandbox would have produced: `sandbox/…`
+/// members owned by a uid that means nothing in the target image.
+fn build_source_archive(dir: &std::path::Path) -> Result<std::path::PathBuf> {
+    let home = dir.join("sandbox");
+    std::fs::create_dir_all(home.join(".platform"))?;
+    std::fs::create_dir_all(home.join(".claude"))?;
+    std::fs::create_dir_all(home.join(".cache"))?;
+    std::fs::create_dir_all(home.join("projects"))?;
+    std::fs::write(home.join("CLAUDE.md"), "# migrated identity\n")?;
+    std::fs::write(home.join(".claude/settings.json"), "{}\n")?;
+    std::fs::write(home.join(".platform/marker"), "platform-owned\n")?;
+    std::fs::write(home.join(".cache/huge.bin"), vec![0u8; 1024])?;
+    std::fs::write(home.join("projects/notes.md"), "notes\n")?;
+
+    let archive = dir.join("sandbox.tar.gz");
+    let status = std::process::Command::new("tar")
+        .arg("czpf")
+        .arg(&archive)
+        .arg("-C")
+        .arg(dir)
+        .arg(format!("--owner={FOREIGN_UID}"))
+        .arg(format!("--group={FOREIGN_UID}"))
+        .args(
+            MIGRATION_EXCLUDES
+                .iter()
+                .map(|path| format!("--exclude=sandbox/{path}")),
+        )
+        .arg("sandbox")
+        .status()
+        .context("run tar")?;
+    anyhow::ensure!(status.success(), "tar failed: {status}");
+    Ok(archive)
+}
+
+#[tokio::test]
+#[ignore = "ci-msb: restores a migration archive into a live microVM"]
+async fn ci_msb_migration_archive_restores_and_verifies() -> Result<()> {
+    ensure_runtime_installed().await?;
+    let dir = tempfile::tempdir()?;
+    let archive = build_source_archive(dir.path())?;
+    let expected = carried_entries(SOURCE_LISTING, MIGRATION_EXCLUDES);
+
+    let name = sandbox_name("ok");
+    let _guard = SandboxGuard(name.clone());
+    let sandbox = boot(&name).await?;
+
+    // The guest user exists in production because provisioning creates it;
+    // create it here so the ownership hand-over is exercised, not skipped.
+    let (code, _) = sh(
+        &sandbox,
+        "id -u sandbox >/dev/null 2>&1 || useradd -M -d /sandbox sandbox",
+    )
+    .await?;
+    anyhow::ensure!(code == 0, "creating the guest user failed");
+
+    restore_archive(&sandbox, &archive)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e:#}"))?;
+    let handed = hand_home_to_guest_user(&sandbox)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e:#}"))?;
+    anyhow::ensure!(handed, "the guest user exists, so the hand-over must run");
+
+    verify_restore(&sandbox, &expected, handed)
+        .await
+        .map_err(|e| anyhow::anyhow!("verification of a good restore failed: {e:#}"))?;
+
+    // Content came across.
+    let (code, content) = sh(&sandbox, "cat /sandbox/CLAUDE.md").await?;
+    anyhow::ensure!(code == 0, "reading a migrated file failed");
+    assert_eq!(content.trim(), "# migrated identity");
+
+    // Excluded caches did not.
+    let (code, _) = sh(&sandbox, "test -e /sandbox/.cache").await?;
+    assert_ne!(
+        code, 0,
+        "an excluded directory was carried into the sandbox"
+    );
+
+    // The foreign uid is gone: agent data belongs to the guest user, and
+    // `.platform` stays root-owned.
+    let (code, owners) = sh(
+        &sandbox,
+        "stat -c '%U' /sandbox/CLAUDE.md /sandbox/.claude /sandbox/projects /sandbox/.platform",
+    )
+    .await?;
+    anyhow::ensure!(code == 0, "stat failed");
+    assert_eq!(
+        owners.split_whitespace().collect::<Vec<_>>(),
+        vec!["sandbox", "sandbox", "sandbox", "root"],
+        "uid remap did not land"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "ci-msb: proves migration verification fails on a partial restore"]
+async fn ci_msb_migration_verification_rejects_a_partial_restore() -> Result<()> {
+    ensure_runtime_installed().await?;
+    let dir = tempfile::tempdir()?;
+    let archive = build_source_archive(dir.path())?;
+    let expected = carried_entries(SOURCE_LISTING, MIGRATION_EXCLUDES);
+
+    let name = sandbox_name("bad");
+    let _guard = SandboxGuard(name.clone());
+    let sandbox = boot(&name).await?;
+
+    restore_archive(&sandbox, &archive)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e:#}"))?;
+
+    // Lose one carried entry the way a truncated stream would.
+    let (code, _) = sh(&sandbox, "rm -rf /sandbox/projects").await?;
+    anyhow::ensure!(code == 0, "removing an entry failed");
+
+    let error = verify_restore(&sandbox, &expected, false)
+        .await
+        .expect_err("verification must reject a home that lost an entry");
+    let rendered = format!("{error:#}");
+    assert!(
+        rendered.contains("projects"),
+        "the error must name the missing entry: {rendered}"
+    );
+    Ok(())
+}

--- a/crates/right-openshell/src/openshell.rs
+++ b/crates/right-openshell/src/openshell.rs
@@ -1181,19 +1181,24 @@ pub async fn tear_down_control_master(config_path: &Path, host: &str, socket_pat
 /// Runs tar from inside the sandbox root and rewrites archive entries under
 /// `sandbox_path`, piping stdout directly to `dest_path` without buffering in
 /// memory.
+///
+/// `excludes` are guest-home-relative paths (`".cache"`,
+/// `".claude/settings.json"`) left out of the archive together with their
+/// children. Plain backups pass [`DEFAULT_REBUILDABLE_BACKUP_EXCLUDES`]; the
+/// sandbox migration passes its own, wider set.
 pub async fn ssh_tar_download(
     config_path: &Path,
     ssh_host: &str,
     sandbox_path: &str,
     dest_path: &Path,
-    include_rebuildable: bool,
+    excludes: &[&str],
     timeout_secs: u64,
 ) -> miette::Result<()> {
     let mut command = Command::new("ssh");
     command.arg("-F").arg(config_path);
     command.arg(ssh_host);
     command.arg("--");
-    let tar_args = sandbox_tar_download_args(sandbox_path, include_rebuildable)?;
+    let tar_args = sandbox_tar_download_args(sandbox_path, excludes)?;
     command.arg(quote_ssh_remote_args(tar_args.iter().map(String::as_str))?);
     command.stdout(Stdio::piped());
     command.stderr(Stdio::piped());
@@ -1275,10 +1280,7 @@ pub fn quote_ssh_remote_args<'a>(
         .map_err(|e| miette::miette!("failed to quote SSH remote command args: {e}"))
 }
 
-fn sandbox_tar_download_args(
-    sandbox_path: &str,
-    include_rebuildable: bool,
-) -> miette::Result<Vec<String>> {
+fn sandbox_tar_download_args(sandbox_path: &str, excludes: &[&str]) -> miette::Result<Vec<String>> {
     let archive_root = sandbox_path.trim_matches('/');
     if archive_root.is_empty() {
         miette::bail!("sandbox path must not be empty");
@@ -1296,13 +1298,11 @@ fn sandbox_tar_download_args(
         format!("--transform=flags=rh;s,^\\./,{archive_root}/,"),
     ];
 
-    if !include_rebuildable {
-        for path in DEFAULT_REBUILDABLE_BACKUP_EXCLUDES {
-            // GNU tar evaluates excludes before transforms, so match names as
-            // seen under `-C /sandbox .`, not final `sandbox/...` archive names.
-            args.push(format!("--exclude=./{path}"));
-            args.push(format!("--exclude=./{path}/*"));
-        }
+    for path in excludes {
+        // GNU tar evaluates excludes before transforms, so match names as
+        // seen under `-C /sandbox .`, not final `sandbox/...` archive names.
+        args.push(format!("--exclude=./{path}"));
+        args.push(format!("--exclude=./{path}/*"));
     }
 
     args.push(".".to_string());

--- a/crates/right-openshell/src/openshell_tests.rs
+++ b/crates/right-openshell/src/openshell_tests.rs
@@ -156,7 +156,7 @@ fn ssh_host_for_sandbox_formats_correctly() {
 #[test]
 fn sandbox_tar_download_args_reads_sandbox_dir_and_preserves_archive_root() {
     assert_eq!(
-        sandbox_tar_download_args("sandbox", true).unwrap(),
+        sandbox_tar_download_args("sandbox", &[]).unwrap(),
         vec![
             "tar",
             "czpf",
@@ -366,8 +366,8 @@ fn sandbox_response_decodes_metadata_and_status_phase_layout() {
 }
 
 #[test]
-fn sandbox_tar_download_args_excludes_rebuildable_dirs_by_default() {
-    let args = sandbox_tar_download_args("sandbox", false).unwrap();
+fn sandbox_tar_download_args_emits_directory_and_child_excludes() {
+    let args = sandbox_tar_download_args("sandbox", DEFAULT_REBUILDABLE_BACKUP_EXCLUDES).unwrap();
 
     assert_eq!(&args[0..5], ["tar", "czpf", "-", "-C", "/sandbox"]);
     assert!(args.contains(&"--transform=flags=rh;s,^\\.$,sandbox,".to_string()));
@@ -387,8 +387,8 @@ fn sandbox_tar_download_args_excludes_rebuildable_dirs_by_default() {
 }
 
 #[test]
-fn sandbox_tar_download_args_include_rebuildable_has_no_rebuildable_excludes() {
-    let args = sandbox_tar_download_args("sandbox", true).unwrap();
+fn sandbox_tar_download_args_without_excludes_emits_no_exclude_flags() {
+    let args = sandbox_tar_download_args("sandbox", &[]).unwrap();
 
     assert_eq!(&args[0..5], ["tar", "czpf", "-", "-C", "/sandbox"]);
     assert!(args.contains(&"--transform=flags=rh;s,^\\.$,sandbox,".to_string()));
@@ -411,7 +411,7 @@ fn sandbox_tar_download_args_include_rebuildable_has_no_rebuildable_excludes() {
 fn sandbox_tar_download_remote_command_quotes_transform_semicolons_for_shell() {
     use std::process::Command;
 
-    let args = sandbox_tar_download_args("sandbox", false).unwrap();
+    let args = sandbox_tar_download_args("sandbox", DEFAULT_REBUILDABLE_BACKUP_EXCLUDES).unwrap();
     let remote_command = quote_ssh_remote_args(args.iter().map(String::as_str)).unwrap();
     let probe = format!(
         "tar() {{ for arg in \"$@\"; do printf '<%s>\\n' \"$arg\"; done; }}; {remote_command}"
@@ -676,7 +676,7 @@ fn sandbox_tar_download_args_preserves_relative_symlink_targets() {
     symlink("./target", src.join("link")).unwrap();
     std::fs::hard_link(src.join("target"), src.join("hard")).unwrap();
 
-    let mut args = sandbox_tar_download_args("sandbox", true).unwrap();
+    let mut args = sandbox_tar_download_args("sandbox", &[]).unwrap();
     assert_eq!(args.remove(0), "tar");
     let archive_arg = args.iter().position(|arg| arg == "-").unwrap();
     args[archive_arg] = archive.to_string_lossy().into_owned();

--- a/crates/right/Cargo.toml
+++ b/crates/right/Cargo.toml
@@ -53,6 +53,7 @@ walkdir = { workspace = true }
 secrecy = { workspace = true }
 tonic = { workspace = true }
 uuid = { workspace = true }
+tempfile = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = "2.2"
@@ -60,6 +61,5 @@ predicates = "3.1"
 right-db = { path = "../right-db", version = "*", features = ["test-support"] }
 right-providers = { path = "../right-providers", version = "*", features = ["test-support"] }
 right-openshell = { path = "../right-openshell", version = "*", features = ["test-support"] }
-tempfile = "3.27"
 tokio = { workspace = true, features = ["test-util"] }
 tower = { version = "0.5", features = ["util"] }

--- a/crates/right/src/main.rs
+++ b/crates/right/src/main.rs
@@ -8,6 +8,7 @@ pub(crate) mod internal_api;
 pub(crate) mod internal_api_providers;
 pub(crate) mod learning;
 mod memory_server;
+pub(crate) mod migrate_sandbox;
 pub(crate) mod progress;
 mod restore;
 pub(crate) mod right_backend;
@@ -43,8 +44,6 @@ pub(crate) const MAIN_PROMPT_LABELS: &[&str] = &[
     "permanently destroy agent '",
     // cmd_agent_rebootstrap: dynamic confirm — agent_name varies, prefix is the static portion
     "rebootstrap agent '",
-    // cmd_agent_config: sandbox migration confirm
-    "migrate sandbox now? (backup old, create new, restore data)",
 ];
 
 #[cfg(test)]
@@ -117,6 +116,24 @@ mod cli_parse_tests {
             };
 
         assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+
+    /// The config parser refuses to start an unmigrated agent and names this
+    /// command verbatim, so the command must exist under exactly that name.
+    #[test]
+    fn migrate_sandbox_is_spelled_the_way_the_config_error_promises() {
+        let cli = Cli::try_parse_from(["right", "agent", "migrate-sandbox", "finance"])
+            .expect("`right agent migrate-sandbox <agent>` must parse");
+        match cli.command {
+            Commands::Agent {
+                command: AgentCommands::MigrateSandbox { name },
+            } => assert_eq!(name, "finance"),
+            _ => panic!("migrate-sandbox did not parse into its own subcommand"),
+        }
+        assert!(
+            right_agent_config::OPENSHELL_UNMIGRATED.contains("right agent migrate-sandbox"),
+            "the rejection message must point at the command that fixes it"
+        );
     }
 
     #[test]
@@ -575,6 +592,15 @@ pub enum AgentCommands {
     Providers {
         #[command(subcommand)]
         command: AgentProvidersCommands,
+    },
+    /// Move an agent out of its OpenShell sandbox into a microsandbox VM.
+    /// The old sandbox is deleted only after the restore is verified; any
+    /// earlier failure leaves the agent exactly as it was, so a failed
+    /// migration can simply be re-run.
+    #[command(name = "migrate-sandbox")]
+    MigrateSandbox {
+        /// Agent name
+        name: String,
     },
 }
 
@@ -1381,6 +1407,9 @@ async fn main() -> miette::Result<()> {
             }
             AgentCommands::Skill { command } => cmd_agent_skill(&home, command).await,
             AgentCommands::Providers { command } => cmd_agent_providers(&home, command).await,
+            AgentCommands::MigrateSandbox { name } => {
+                migrate_sandbox::cmd_agent_migrate_sandbox(&home, &name).await
+            }
         },
         Commands::Memory { command } => match command {
             MemoryCommands::List {

--- a/crates/right/src/migrate_sandbox.rs
+++ b/crates/right/src/migrate_sandbox.rs
@@ -1,0 +1,498 @@
+//! `right agent migrate-sandbox <agent>` — move an agent out of its OpenShell
+//! sandbox and into a microsandbox VM.
+//!
+//! Ordering is the entire safety story. The OpenShell sandbox is deleted only
+//! after the new sandbox has been created, restored, and *verified*; every
+//! earlier failure deletes the half-built microVM and leaves both the OpenShell
+//! sandbox and the on-disk `agent.yaml` exactly as they were, so re-running the
+//! command after a partial failure starts from the same clean state.
+//!
+//! Credentials are the one thing that cannot come along: OpenShell's
+//! `GetProvider` returns `"REDACTED"`, so a provider's value is unreadable by
+//! design. The command reports the providers the old sandbox had attached and
+//! points the operator at the dashboard's `/providers` flow — the same path
+//! that adds a provider to any other agent.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use right_agent::sandbox_migrate::{
+    MIGRATION_EXCLUDES, carried_entries, hand_home_to_guest_user, restore_archive, verify_restore,
+};
+
+/// Guest home in *both* runtimes: OpenShell's sandbox root and
+/// [`right_sandbox::GUEST_HOME`] are both `/sandbox`, which is why the archive
+/// the migration downloads has the same `sandbox/…` member layout as a
+/// microsandbox backup and restores through the same `--strip-components=1`.
+const OPENSHELL_GUEST_HOME: &str = "/sandbox";
+
+/// How long the OpenShell-side `tar` stream may take.
+const ARCHIVE_TIMEOUT_SECS: u64 = 900;
+
+/// How long the source sandbox gets to reach READY before the migration gives
+/// up on reading it.
+const OPENSHELL_READY_TIMEOUT_SECS: u64 = 120;
+
+/// How long to wait for the OpenShell gateway to confirm the old sandbox is
+/// gone.
+const OPENSHELL_DELETE_TIMEOUT_SECS: u64 = 180;
+
+/// Poll interval for the OpenShell readiness/deletion waits.
+const OPENSHELL_POLL_INTERVAL_SECS: u64 = 2;
+
+/// Server-side timeout for the `ls` probe that captures the source listing.
+const SOURCE_LISTING_TIMEOUT_SECS: u32 = 30;
+
+/// The OpenShell gRPC client this command drives. The old sandbox is the only
+/// reason `right` still talks to OpenShell at all.
+type OpenShellGrpc =
+    right_openshell::openshell_proto::openshell::v1::open_shell_client::OpenShellClient<
+        tonic::transport::Channel,
+    >;
+
+/// Where `agent.yaml` says this agent currently lives.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum MigrationSource {
+    /// `sandbox.mode: openshell` — an unmigrated agent whose home is still in
+    /// the named (or derived) OpenShell sandbox.
+    OpenShell { explicit_name: Option<String> },
+    /// No `sandbox.mode:` key: the agent already runs in a microsandbox VM and
+    /// the command is a no-op.
+    AlreadyMigrated,
+}
+
+/// Minimal read-only view of the *unmigrated* `agent.yaml`.
+///
+/// The real parser (`right_agent_config`) deliberately rejects
+/// `sandbox.mode: openshell` — that rejection is what stops an unmigrated agent
+/// from starting — so this command cannot use it to read its own input.
+#[derive(Debug, Deserialize)]
+struct SourceAgentYaml {
+    #[serde(default)]
+    sandbox: Option<SourceSandbox>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SourceSandbox {
+    #[serde(default)]
+    mode: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+}
+
+/// Classify an `agent.yaml` for migration.
+///
+/// Any `mode:` other than `openshell` is an error rather than a guess: `none`
+/// is the retired sandboxless mode, whose files live on the host and need a
+/// different migration, and an unknown value means the file was hand-edited.
+pub(crate) fn migration_source(yaml: &str) -> miette::Result<MigrationSource> {
+    let parsed: SourceAgentYaml = serde_saphyr::from_str(yaml)
+        .map_err(|e| miette::miette!("agent.yaml is not valid YAML: {e}"))?;
+    let Some(sandbox) = parsed.sandbox else {
+        return Ok(MigrationSource::AlreadyMigrated);
+    };
+    match sandbox.mode.as_deref() {
+        None => Ok(MigrationSource::AlreadyMigrated),
+        Some("openshell") => Ok(MigrationSource::OpenShell {
+            explicit_name: sandbox.name,
+        }),
+        Some("none") => Err(miette::miette!(
+            help = "Sandboxless agents keep their files on the host; this command only moves an OpenShell sandbox.",
+            "`sandbox.mode: none` is not an OpenShell agent"
+        )),
+        Some(other) => Err(miette::miette!(
+            "unknown `sandbox.mode: {other}` in agent.yaml; only `openshell` can be migrated"
+        )),
+    }
+}
+
+/// Rewrite an unmigrated `agent.yaml` for the microsandbox world.
+///
+/// Drops the two retired keys (`mode:`, `policy_file:`) and writes the new
+/// `sandbox.name`, leaving every other line — comments, providers, key order —
+/// untouched. Deliberately *not*
+/// `crate::wizard::update_agent_yaml_sandbox_name`: that helper preserves
+/// `mode:`, which is precisely the line that makes the agent unstartable.
+pub(crate) fn rewrite_agent_yaml_for_migration(yaml: &str, sandbox_name: &str) -> String {
+    let name_line = format!("  name: \"{sandbox_name}\"");
+    let mut lines: Vec<String> = Vec::new();
+    let mut in_sandbox_block = false;
+    let mut wrote_block = false;
+
+    for line in yaml.lines() {
+        if line.trim_end() == "sandbox:" {
+            in_sandbox_block = true;
+            wrote_block = true;
+            lines.push("sandbox:".to_owned());
+            lines.push(name_line.clone());
+            continue;
+        }
+        if in_sandbox_block {
+            if line.trim().is_empty() || line.starts_with(' ') || line.starts_with('\t') {
+                let key = line.trim_start();
+                if key.starts_with("mode:")
+                    || key.starts_with("policy_file:")
+                    || key.starts_with("name:")
+                {
+                    continue;
+                }
+                lines.push(line.to_owned());
+                continue;
+            }
+            in_sandbox_block = false;
+        }
+        lines.push(line.to_owned());
+    }
+
+    if !wrote_block {
+        lines.push("sandbox:".to_owned());
+        lines.push(name_line);
+    }
+
+    let mut output = lines.join("\n");
+    if !output.ends_with('\n') {
+        output.push('\n');
+    }
+    output
+}
+
+/// Everything the migration learned about the source before touching anything.
+struct SourcePlan {
+    /// OpenShell sandbox holding the agent's home.
+    old_name: String,
+    /// Deterministic microsandbox name the agent moves to.
+    new_name: String,
+    /// `agent.yaml` as it will be written once the restore is verified.
+    migrated_yaml: String,
+    /// The migrated config, parsed to build the create-time spec.
+    migrated_config: right_agent::agent::types::AgentConfig,
+}
+
+/// Read `agent.yaml`, decide what the migration will do, and prove the
+/// rewritten config parses — all before a single side effect.
+fn plan_migration(agent_name: &str, yaml: &str) -> miette::Result<Option<SourcePlan>> {
+    let explicit_name = match migration_source(yaml)? {
+        MigrationSource::AlreadyMigrated => return Ok(None),
+        MigrationSource::OpenShell { explicit_name } => explicit_name,
+    };
+    let old_name =
+        right_openshell::openshell::resolve_sandbox_name(agent_name, explicit_name.as_deref());
+    let new_name = right_sandbox::sandbox_name(agent_name);
+    let migrated_yaml = rewrite_agent_yaml_for_migration(yaml, &new_name);
+    let migrated_config: right_agent::agent::types::AgentConfig =
+        serde_saphyr::from_str(&migrated_yaml).map_err(|e| {
+            miette::miette!("the migrated agent.yaml would not parse — migration aborted: {e}")
+        })?;
+    Ok(Some(SourcePlan {
+        old_name,
+        new_name,
+        migrated_yaml,
+        migrated_config,
+    }))
+}
+
+/// Connect to the OpenShell gateway, or explain what is missing.
+async fn connect_openshell() -> miette::Result<OpenShellGrpc> {
+    use right_openshell::openshell::{OpenShellStatus, connect_grpc, preflight_check};
+
+    let mtls_dir = match preflight_check() {
+        OpenShellStatus::Ready(dir) => dir,
+        OpenShellStatus::NotInstalled => {
+            return Err(miette::miette!(
+                help = "Install OpenShell and start its gateway, then re-run the migration.",
+                "the `openshell` CLI is not installed, so this agent's old sandbox cannot be read"
+            ));
+        }
+        OpenShellStatus::NoGateway(dir) | OpenShellStatus::BrokenGateway(dir) => {
+            return Err(miette::miette!(
+                help = "Start the OpenShell gateway, then re-run the migration.",
+                "no usable OpenShell gateway at {} — this agent's old sandbox cannot be read",
+                dir.display()
+            ));
+        }
+    };
+    connect_grpc(&mtls_dir).await
+}
+
+/// Download the agent's OpenShell home and capture what the source held.
+///
+/// The archive is written into `~/.right/backups/<agent>/<stamp>/` and kept:
+/// it is the operator's independent copy of the pre-migration home, and it
+/// costs nothing to leave behind.
+async fn archive_openshell_home(
+    client: &mut OpenShellGrpc,
+    old_name: &str,
+    migration_dir: &Path,
+) -> miette::Result<(PathBuf, Vec<String>)> {
+    use right_openshell::openshell;
+
+    let sandbox_id = openshell::resolve_sandbox_id(client, old_name).await?;
+    let (listing, code) = openshell::exec_in_sandbox(
+        client,
+        &sandbox_id,
+        &["ls", "-A", OPENSHELL_GUEST_HOME],
+        SOURCE_LISTING_TIMEOUT_SECS,
+    )
+    .await?;
+    if code != 0 {
+        return Err(miette::miette!(
+            "listing '{OPENSHELL_GUEST_HOME}' in sandbox '{old_name}' exited with {code}"
+        ));
+    }
+    let carried = carried_entries(&listing, MIGRATION_EXCLUDES);
+    if carried.is_empty() {
+        return Err(miette::miette!(
+            "sandbox '{old_name}' has nothing to migrate under {OPENSHELL_GUEST_HOME}"
+        ));
+    }
+
+    let ssh_config = openshell::generate_ssh_config(old_name, migration_dir).await?;
+    let ssh_host = openshell::ssh_host_for_sandbox(old_name);
+    let archive = migration_dir.join("sandbox.tar.gz");
+    let download = openshell::ssh_tar_download(
+        &ssh_config,
+        &ssh_host,
+        OPENSHELL_GUEST_HOME,
+        &archive,
+        MIGRATION_EXCLUDES,
+        ARCHIVE_TIMEOUT_SECS,
+    )
+    .await;
+    openshell::tear_down_control_master(
+        &ssh_config,
+        &ssh_host,
+        &openshell::control_master_socket_path(migration_dir, old_name),
+    )
+    .await;
+    download?;
+
+    Ok((archive, carried))
+}
+
+/// `right agent migrate-sandbox <agent>`.
+///
+/// Steps, in the only order that is safe:
+/// 1. read `agent.yaml`; an already-migrated agent is a no-op success,
+/// 2. archive the OpenShell home (kept as a backup) and record its listing,
+/// 3. create the microsandbox VM from the same spec builder the bot uses,
+/// 4. restore the archive and hand the home to the guest user,
+/// 5. verify the restore — nothing destructive has happened yet,
+/// 6. write the rewritten `agent.yaml`,
+/// 7. delete the OpenShell sandbox.
+///
+/// A failure anywhere in 1–5 deletes the new sandbox and leaves the OpenShell
+/// one and the original `agent.yaml` untouched, so the agent stays exactly as
+/// runnable as it was and the command can simply be run again.
+pub(crate) async fn cmd_agent_migrate_sandbox(home: &Path, agent_name: &str) -> miette::Result<()> {
+    let theme = right_ui::detect();
+    let agents_dir = right_config::agents_dir(home);
+    let agent_dir = agents_dir.join(agent_name);
+    if !agent_dir.is_dir() {
+        return Err(miette::miette!(
+            help = "List agents with: right agent list",
+            "agent '{agent_name}' not found at {}",
+            agent_dir.display()
+        ));
+    }
+    let yaml_path = agent_dir.join("agent.yaml");
+    let yaml = std::fs::read_to_string(&yaml_path)
+        .map_err(|e| miette::miette!("read {}: {e:#}", yaml_path.display()))?;
+
+    let Some(plan) = plan_migration(agent_name, &yaml)? else {
+        println!(
+            "{}",
+            right_ui::status(right_ui::Glyph::Ok)
+                .noun("agent")
+                .verb("already migrated")
+                .detail(agent_name)
+                .render(theme)
+        );
+        return Ok(());
+    };
+
+    println!(
+        "{}",
+        right_ui::section(theme, &format!("agent migrate-sandbox: {agent_name}"))
+    );
+
+    // Preflight: both runtimes must be usable before anything is copied.
+    let mut client = connect_openshell().await?;
+    if !right_openshell::openshell::sandbox_exists(&mut client, &plan.old_name).await? {
+        return Err(miette::miette!(
+            help = "Restore the agent from a backup instead: right agent restore",
+            "OpenShell sandbox '{}' does not exist, so agent '{agent_name}' has no home to migrate",
+            plan.old_name
+        ));
+    }
+    right_sandbox::ensure_runtime_installed()
+        .await
+        .map_err(|error| miette::miette!("install the sandbox runtime: {error:#}"))?;
+    right_sandbox::diagnose_host()
+        .map_err(|error| miette::miette!("this host cannot run microVMs: {error:#}"))?;
+    right_openshell::openshell::wait_for_ready(
+        &mut client,
+        &plan.old_name,
+        OPENSHELL_READY_TIMEOUT_SECS,
+        OPENSHELL_POLL_INTERVAL_SECS,
+    )
+    .await?;
+
+    // Providers are read before the source is deleted: their values are
+    // unreadable by design, so their names are all the operator gets back.
+    let attached_providers = right_openshell::providers::list_attached(&mut client, &plan.old_name)
+        .await
+        .map_err(|error| {
+            miette::miette!("list providers attached to '{}': {error:#}", plan.old_name)
+        })?;
+
+    let stamp = chrono::Local::now().format("%Y%m%d-%H%M%S").to_string();
+    let migration_dir =
+        right_config::backups_dir(home, agent_name).join(format!("migrate-{stamp}"));
+    std::fs::create_dir_all(&migration_dir)
+        .map_err(|e| miette::miette!("create {}: {e:#}", migration_dir.display()))?;
+
+    println!(
+        "{}",
+        right_ui::status(right_ui::Glyph::Info)
+            .noun("openshell sandbox")
+            .verb("archiving")
+            .detail(&plan.old_name)
+            .render(theme)
+    );
+    let (archive, carried) =
+        archive_openshell_home(&mut client, &plan.old_name, &migration_dir).await?;
+    println!(
+        "{}",
+        right_ui::status(right_ui::Glyph::Ok)
+            .noun("archive")
+            .verb("written")
+            .detail(archive.display().to_string())
+            .render(theme)
+    );
+
+    let providers = right_providers::ProviderStore::open(home)
+        .await
+        .map_err(|error| miette::miette!("open provider store: {error:#}"))?;
+    let spec = right_bot::agent_sandbox_spec_for(
+        agent_name,
+        &plan.new_name,
+        &plan.migrated_config,
+        &providers,
+    )
+    .await?;
+
+    println!(
+        "{}",
+        right_ui::status(right_ui::Glyph::Info)
+            .noun("sandbox")
+            .verb("creating")
+            .detail(&plan.new_name)
+            .render(theme)
+    );
+    let sandbox = right_sandbox::SandboxHandle::create_or_attach(&spec)
+        .await
+        .map_err(|error| miette::miette!("create sandbox '{}': {error:#}", plan.new_name))?;
+
+    // From here the new sandbox exists, so every failure rolls it back.
+    let restored = async {
+        sandbox
+            .wait_ready(right_sandbox::DEFAULT_READY_TIMEOUT)
+            .await
+            .map_err(|error| {
+                miette::miette!("sandbox '{}' never became ready: {error:#}", plan.new_name)
+            })?;
+        restore_archive(&sandbox, &archive).await?;
+        let handed_to_guest = hand_home_to_guest_user(&sandbox).await?;
+        verify_restore(&sandbox, &carried, handed_to_guest).await?;
+        Ok::<bool, miette::Report>(handed_to_guest)
+    }
+    .await;
+
+    let handed_to_guest = match restored {
+        Ok(handed) => handed,
+        Err(error) => {
+            // The OpenShell sandbox and agent.yaml are still untouched, so
+            // dropping the half-built microVM restores the exact prior state.
+            right_sandbox::SandboxHandle::delete(&plan.new_name)
+                .await
+                .map_err(|cleanup| {
+                    miette::miette!(
+                        "migration failed: {error:#}; deleting the half-migrated sandbox '{}' also failed: {cleanup:#}",
+                        plan.new_name
+                    )
+                })?;
+            return Err(miette::miette!(
+                "migration failed: {error:#}. Agent '{agent_name}' still runs from OpenShell sandbox '{}'; its archive is at {}",
+                plan.old_name,
+                archive.display()
+            ));
+        }
+    };
+
+    // Verified: the agent can now be pointed at the new sandbox.
+    std::fs::write(&yaml_path, &plan.migrated_yaml)
+        .map_err(|e| miette::miette!("write {}: {e:#}", yaml_path.display()))?;
+    right_agent::agent::discovery::parse_agent_config(&agent_dir)?;
+
+    right_openshell::openshell::delete_sandbox_confirmed(
+        &mut client,
+        &plan.old_name,
+        OPENSHELL_DELETE_TIMEOUT_SECS,
+        OPENSHELL_POLL_INTERVAL_SECS,
+    )
+    .await
+    .map_err(|error| {
+        miette::miette!(
+            help = "Delete it with: openshell sandbox delete <name>",
+            "agent '{agent_name}' is migrated and now runs in sandbox '{}', but deleting the old OpenShell sandbox '{}' failed: {error:#}",
+            plan.new_name,
+            plan.old_name
+        )
+    })?;
+
+    println!(
+        "{}",
+        migration_recap(&plan, &archive, handed_to_guest, &attached_providers).render(theme)
+    );
+    Ok(())
+}
+
+/// Final report: what moved, what stayed behind, and what the operator still
+/// has to do by hand.
+fn migration_recap(
+    plan: &SourcePlan,
+    archive: &Path,
+    handed_to_guest: bool,
+    attached_providers: &[String],
+) -> right_ui::Recap {
+    let mut recap = right_ui::Recap::new("migrated")
+        .ok("sandbox", &plan.new_name)
+        .ok("archive", &archive.display().to_string())
+        .ok("openshell sandbox", &format!("{} deleted", plan.old_name));
+    if !handed_to_guest {
+        recap = recap.warn(
+            "ownership",
+            &format!(
+                "migrated files are root-owned until provisioning creates the '{}' user",
+                right_sandbox::GUEST_USER
+            ),
+        );
+    }
+    if !attached_providers.is_empty() {
+        recap = recap
+            .warn(
+                "providers",
+                &format!(
+                    "credentials could not be carried (OpenShell redacts them): {}",
+                    attached_providers.join(", ")
+                ),
+            )
+            .next("re-add each provider from the dashboard: /providers");
+    }
+    recap
+}
+
+#[cfg(test)]
+#[path = "migrate_sandbox_tests.rs"]
+mod tests;

--- a/crates/right/src/migrate_sandbox.rs
+++ b/crates/right/src/migrate_sandbox.rs
@@ -247,7 +247,12 @@ async fn archive_openshell_home(
         ));
     }
 
-    let ssh_config = openshell::generate_ssh_config(old_name, migration_dir).await?;
+    // The SSH config and control-master socket are transport scratch, not
+    // backup content: keep them in a temp dir so the migration directory the
+    // operator is told to treat as a backup holds only the archive.
+    let ssh_dir =
+        tempfile::tempdir().map_err(|e| miette::miette!("create ssh working directory: {e:#}"))?;
+    let ssh_config = openshell::generate_ssh_config(old_name, ssh_dir.path()).await?;
     let ssh_host = openshell::ssh_host_for_sandbox(old_name);
     let archive = migration_dir.join("sandbox.tar.gz");
     let download = openshell::ssh_tar_download(
@@ -262,7 +267,7 @@ async fn archive_openshell_home(
     openshell::tear_down_control_master(
         &ssh_config,
         &ssh_host,
-        &openshell::control_master_socket_path(migration_dir, old_name),
+        &openshell::control_master_socket_path(ssh_dir.path(), old_name),
     )
     .await;
     download?;

--- a/crates/right/src/migrate_sandbox_tests.rs
+++ b/crates/right/src/migrate_sandbox_tests.rs
@@ -1,0 +1,164 @@
+//! Pure-part tests for `right agent migrate-sandbox`: what the command decides
+//! and writes before it ever touches a sandbox.
+
+use std::collections::HashSet;
+
+use right_agent::sandbox_migrate::{entry_name, missing_entries};
+
+use super::{
+    MIGRATION_EXCLUDES, MigrationSource, carried_entries, migration_source, plan_migration,
+    rewrite_agent_yaml_for_migration,
+};
+
+const OPENSHELL_YAML: &str = "\
+network_policy: permissive
+# keep this comment
+sandbox:
+  mode: openshell
+  policy_file: policy.yaml
+  name: right-finance
+memory:
+  provider: file
+";
+
+#[test]
+fn openshell_agent_is_a_migration_source() {
+    assert_eq!(
+        migration_source(OPENSHELL_YAML).expect("parses"),
+        MigrationSource::OpenShell {
+            explicit_name: Some("right-finance".to_owned())
+        }
+    );
+}
+
+#[test]
+fn migrated_agent_is_a_no_op() {
+    let yaml = "name: finance\nsandbox:\n  name: right-finance\n";
+    assert_eq!(
+        migration_source(yaml).expect("parses"),
+        MigrationSource::AlreadyMigrated
+    );
+    assert_eq!(
+        migration_source("name: finance\n").expect("parses"),
+        MigrationSource::AlreadyMigrated
+    );
+}
+
+#[test]
+fn sandboxless_and_unknown_modes_are_rejected() {
+    for mode in ["none", "chroot"] {
+        let yaml = format!("sandbox:\n  mode: {mode}\n");
+        assert!(
+            migration_source(&yaml).is_err(),
+            "mode {mode} must not be treated as an OpenShell source"
+        );
+    }
+}
+
+#[test]
+fn rewrite_drops_retired_keys_and_sets_the_new_name() {
+    let rewritten = rewrite_agent_yaml_for_migration(OPENSHELL_YAML, "right-finance-msb");
+
+    assert!(!rewritten.contains("mode:"), "mode: survived: {rewritten}");
+    assert!(
+        !rewritten.contains("policy_file:"),
+        "policy_file: survived: {rewritten}"
+    );
+    assert!(rewritten.contains("  name: \"right-finance-msb\""));
+    // Untouched lines keep their content and order.
+    assert!(rewritten.contains("# keep this comment"));
+    assert!(rewritten.starts_with("network_policy: permissive\n"));
+    assert!(rewritten.ends_with("memory:\n  provider: file\n"));
+}
+
+#[test]
+fn rewrite_preserves_other_sandbox_keys() {
+    let yaml = "\
+sandbox:
+  mode: openshell
+  providers:
+    - name: finance-github
+      type: github
+";
+    let rewritten = rewrite_agent_yaml_for_migration(yaml, "right-finance");
+    assert!(rewritten.contains("  providers:"));
+    assert!(rewritten.contains("    - name: finance-github"));
+    assert!(!rewritten.contains("mode:"));
+}
+
+#[test]
+fn rewrite_is_idempotent() {
+    let once = rewrite_agent_yaml_for_migration(OPENSHELL_YAML, "right-finance-msb");
+    let twice = rewrite_agent_yaml_for_migration(&once, "right-finance-msb");
+    assert_eq!(once, twice);
+}
+
+#[test]
+fn rewrite_adds_a_sandbox_block_when_there_is_none() {
+    let rewritten = rewrite_agent_yaml_for_migration("name: finance\n", "right-finance");
+    assert!(rewritten.ends_with("sandbox:\n  name: \"right-finance\"\n"));
+}
+
+#[test]
+fn plan_resolves_both_names_and_validates_the_rewrite() {
+    let plan = plan_migration("finance", OPENSHELL_YAML)
+        .expect("plans")
+        .expect("openshell agent is migratable");
+    assert_eq!(plan.old_name, "right-finance");
+    assert_eq!(plan.new_name, right_sandbox::sandbox_name("finance"));
+    // The rewritten config is what the new sandbox spec is built from, so it
+    // must parse through the real (openshell-rejecting) parser.
+    assert_eq!(
+        plan.migrated_config
+            .sandbox
+            .as_ref()
+            .and_then(|s| s.name.as_deref()),
+        Some(plan.new_name.as_str())
+    );
+    assert!(
+        plan_migration("finance", "name: finance\n")
+            .expect("plans")
+            .is_none()
+    );
+}
+
+#[test]
+fn carried_entries_drop_only_excluded_top_level_names() {
+    let listing = ".cache\n.claude\n.npm\n.platform\nCLAUDE.md\n.ssh\nprojects\n";
+    assert_eq!(
+        carried_entries(listing, MIGRATION_EXCLUDES),
+        vec![".claude", ".platform", "CLAUDE.md", "projects"]
+    );
+}
+
+#[test]
+fn nested_excludes_keep_their_parent_entry() {
+    let listing = ".claude\n";
+    assert_eq!(
+        carried_entries(listing, &[".claude/settings.json"]),
+        vec![".claude"]
+    );
+}
+
+#[test]
+fn entry_names_survive_both_listing_shapes() {
+    assert_eq!(entry_name("/sandbox/.claude"), ".claude");
+    assert_eq!(entry_name(".claude"), ".claude");
+    assert_eq!(entry_name("/sandbox/projects/"), "projects");
+}
+
+#[test]
+fn verification_reports_every_entry_that_did_not_arrive() {
+    let expected = vec![
+        ".claude".to_owned(),
+        "CLAUDE.md".to_owned(),
+        "projects".to_owned(),
+    ];
+    let present: HashSet<&str> = [".claude"].into_iter().collect();
+    assert_eq!(
+        missing_entries(&expected, &present),
+        vec!["CLAUDE.md", "projects"]
+    );
+    let all: HashSet<&str> = [".claude", "CLAUDE.md", "projects"].into_iter().collect();
+    assert!(missing_entries(&expected, &all).is_empty());
+}

--- a/crates/right/tests/cli_rebootstrap.rs
+++ b/crates/right/tests/cli_rebootstrap.rs
@@ -100,7 +100,7 @@ async fn rebootstrap_unavailable_sandbox_preserves_host_sessions_and_answers() {
     std::fs::create_dir_all(&agent_dir).unwrap();
     std::fs::write(
         agent_dir.join("agent.yaml"),
-        "sandbox:\n  mode: openshell\n  name: missing-sandbox\n  policy_file: policy.yaml\n",
+        "sandbox:\n  name: missing-sandbox\n  policy_file: policy.yaml\n",
     )
     .unwrap();
     std::fs::write(agent_dir.join("policy.yaml"), "version: 1\n").unwrap();

--- a/docs/architecture/sandbox.md
+++ b/docs/architecture/sandbox.md
@@ -4,6 +4,30 @@
 > subsystem (see `AGENTS.md` → "Architecture docs split"). Code is
 > authoritative; this file may have drifted.
 
+## Migrating out of OpenShell
+
+`right agent migrate-sandbox <agent>` moves an agent whose `agent.yaml` still
+carries `sandbox.mode: openshell` into a microsandbox VM. The order is the
+safety property, so it is worth stating: archive the OpenShell home (kept under
+`~/.right/backups/<agent>/migrate-<stamp>/`), create the new sandbox from the
+same spec builder the bot uses, extract with `--no-same-owner`, hand every
+top-level entry except `.platform` to the guest user, **verify**, only then
+rewrite `agent.yaml`, and only then delete the OpenShell sandbox. Any failure
+before the verification deletes the new sandbox and leaves both the OpenShell
+sandbox and the original `agent.yaml` untouched, so the command can just be run
+again.
+
+Provider credentials do not come along: OpenShell's `GetProvider` returns
+`"REDACTED"`, so the migration reports the provider names the old sandbox had
+attached and the operator re-adds them from the dashboard's `/providers` flow.
+Writing credential-less provider records instead would be worse than useless —
+the bot hard-fails startup on a provider it cannot bind, which would take the
+dashboard down with it.
+
+Code: `crates/right/src/migrate_sandbox.rs` (OpenShell side, `agent.yaml`
+rewrite) and `right_agent::sandbox_migrate` (guest side: extract, ownership,
+verification).
+
 ## OpenShell Sandbox Architecture
 
 Sandboxes are **persistent** — never deleted automatically. They live as long as the agent lives and survive bot restarts.


### PR DESCRIPTION
Stage 5 of the microsandbox migration (#172). The one-time command that moves an existing agent out of its OpenShell sandbox into a microVM. Stacked on #176. Review only `msb/04-rewire..HEAD`.

This is the command that can destroy an agent, so **ordering is the safety property, and it is structurally enforced**: nothing is written to `agent.yaml` and nothing is deleted until verification returns `Ok`. A failure in steps 1-5 leaves the OpenShell sandbox and `agent.yaml` byte-identical, and the agent exactly as runnable as before.

1. **Preflight, no side effects.** `agent.yaml` is read raw — the real parser now rejects `mode: openshell`, so it cannot parse its own input. The rewritten yaml is computed *and* parsed through the real parser here, so a bad rewrite aborts before anything moves. Already-migrated is a no-op success.
2. **Archive out** over SSH+tar into `~/.right/backups/<agent>/migrate-<stamp>/` — kept rather than temp, so the operator keeps an independent copy. The source's top-level listing is captured first and drives verification.
3. **Create** the msb sandbox via the same shared spec builder the bot's bring-up and `agent restore` use.
4. **Restore with uid remap.** Extract as root with `--no-same-owner` (OpenShell's numeric uids mean something else in the new image), then `chown -R` to the guest user over every top-level entry except `.platform` — which stays root-owned per the stage-1 finding that file permissions don't protect directory entries.
5. **Verify before anything destructive**: every carried entry present, non-empty, owned by the guest user.
6. **Only then** rewrite `agent.yaml`, dropping `mode:`/`policy_file:` and setting `name:`. A dedicated pure rewrite fn — deliberately not `wizard::update_agent_yaml_sandbox_name`, which preserves `mode:`. The file is re-parsed from disk as the post-condition.
7. **Delete the OpenShell sandbox last.** A failure there reports that the migration succeeded, names the new sandbox, and gives the manual delete command.

## Rollback
Failure after the new sandbox exists deletes only the half-built microVM; if that cleanup also fails, both errors are reported together. The error always names the OpenShell sandbox the agent still runs from and the archive path. Re-running after a partial failure is safe (deterministic target name, idempotent re-extract, verification re-runs from scratch).

## Providers
Credentials are not recoverable, so metadata is **reported, not written**: the recap names which providers need a credential re-entered via the dashboard `/providers` flow.

## Bot refusal
`right-agent-config` rejects `mode: openshell` with a message naming this command. Config parse is the single startup chokepoint every path goes through, so an unmigrated agent cannot start anywhere.

## Verification
right + right-agent: **881 passed**. `cargo check --workspace --tests` green. Two `ci_msb_*` live-VM tests cover restore + uid remap.

`right-openshell` is still present on purpose — this command is its last legitimate consumer. Stage 6 deletes the crate.