### PR TITLE
chore(openshell): re-vendor proto to v0.0.110

### DIFF
--- a/crates/right-openshell/proto/UPSTREAM.md
+++ b/crates/right-openshell/proto/UPSTREAM.md
@@ -1,3 +1,3 @@
-tag: v0.0.105
-fetched: 2026-08-13T15:44:21Z
+tag: v0.0.110
+fetched: 2026-08-21T05:50:30Z
 upstream: https://github.com/NVIDIA/OpenShell

--- a/crates/right-openshell/proto/openshell/openshell.proto
+++ b/crates/right-openshell/proto/openshell/openshell.proto
@@ -682,10 +682,16 @@ message IssueSandboxTokenResponse {
   int64 expires_at_ms = 2;
 }
 
-// RefreshSandboxToken request. Empty body; the calling principal must
-// already be a sandbox principal (i.e. the request carries a still-valid
-// gateway-minted JWT in its Authorization header).
-message RefreshSandboxTokenRequest {}
+// RefreshSandboxToken request. The calling principal must already be a
+// sandbox principal (i.e. the request carries a still-valid gateway-minted
+// JWT in its Authorization header). Extension service names are resolved
+// against server-owned registrations and the sandbox's effective policy;
+// callers never choose token audiences directly.
+message RefreshSandboxTokenRequest {
+  // Operator registration names for extension services selected by the
+  // sandbox's effective policy.
+  repeated string extension_service_names = 1;
+}
 
 // RefreshSandboxToken response. The new token replaces the supervisor's
 // in-memory bearer credential.
@@ -695,7 +701,11 @@ message RefreshSandboxTokenResponse {
   // Absolute expiry of the new token, milliseconds since the epoch. 0 means
   // the token is non-expiring.
   int64 expires_at_ms = 2;
+  // Fresh credentials for the requested, policy-authorized extension
+  // services. These remain in supervisor memory and are never persisted.
+  repeated ExtensionServiceCredential extension_credentials = 3;
 }
+
 
 // Health check request.
 message HealthRequest {}
@@ -1569,6 +1579,9 @@ message StoredProviderCredentialRefreshState {
   string credential_key = 4;
   ProviderCredentialRefreshStrategy strategy = 5;
   map<string, string> material = 6 [(openshell.options.v1.secret) = true];
+  // Material names classified as secret. Newly configured values live in the
+  // active credential driver and are absent from material. Legacy inline values
+  // are not automatically migrated before OpenShell 0.1.0.
   repeated string secret_material_keys = 7;
   int64 expires_at_ms = 8;
   int64 next_refresh_at_ms = 9;
@@ -1584,6 +1597,28 @@ message StoredProviderCredentialRefreshState {
   // collision reservation, and env-key surfacing so later profile edits cannot
   // silently redirect writes.
   map<string, string> additional_output_keys = 17;
+  // Opaque gateway-owned authorization epoch for the configured refresh
+  // grant. Explicit refresh configuration creates a new epoch; automatic and
+  // manual token rotation preserve it. It is never derived from or exposed
+  // with refresh material.
+  string authorization_epoch = 18;
+  // Secret refresh material is stored through the gateway's active credential
+  // driver. The persisted refresh state keeps only opaque handles; resolved
+  // values exist in gateway memory for the duration of one mint operation.
+  map<string, openshell.datamodel.v1.CredentialHandle> secret_material_handles = 19;
+  // Handles replaced by reconfiguration or issuer-driven refresh-token
+  // rotation. This is a repeated entry rather than a material-keyed map so
+  // multiple superseded generations of the same material remain recoverable.
+  // Cleanup is retried by the refresh worker so a gateway crash or temporary
+  // credential-backend outage does not lose the deletion reference.
+  repeated StoredRefreshMaterialDeletion pending_secret_deletions = 20;
+}
+
+message StoredRefreshMaterialDeletion {
+  // Original material name used to derive the credential driver's storage key.
+  string material_key = 1;
+  // Opaque handle for the superseded secret object.
+  openshell.datamodel.v1.CredentialHandle handle = 2;
 }
 
 message GetProviderRefreshStatusRequest {
@@ -1602,6 +1637,9 @@ message ConfigureProviderRefreshRequest {
   string credential_key = 2;
   ProviderCredentialRefreshStrategy strategy = 3;
   map<string, string> material = 4 [(openshell.options.v1.secret) = true];
+  // Additional material names the caller requests be stored as secrets. Every
+  // name must be present in material. The server also classifies secrets from
+  // the authoritative provider profile and refresh strategy.
   repeated string secret_material_keys = 5;
   optional int64 expires_at_ms = 6;
   // Workspace scope. Empty defaults to "default".
@@ -1780,6 +1818,12 @@ message StaticCredentialBinding {
   // Supervisors use it to retain old revision placeholders only across
   // rotations of the same provider credential.
   string credential_identity = 2;
+  // Opaque gateway-issued handle for a refresh-managed credential identity
+  // epoch. When non-empty, supervisors keep the workload placeholder stable
+  // across access-token rotations and replace only the resolver value. The
+  // handle changes when the sandbox, provider, credential key, refresh
+  // authorization epoch, or endpoint authorization boundary changes.
+  string workload_credential_handle = 3;
 }
 
 // Get sandbox provider environment response.
@@ -2662,4 +2706,17 @@ message ListWorkspaceMembersRequest {
 // List workspace members response.
 message ListWorkspaceMembersResponse {
   repeated WorkspaceMember members = 1;
+}
+
+// Short-lived credential for one policy-authorized extension service.
+// Kept at the end of the file so adding it does not renumber existing
+// generated message descriptors.
+message ExtensionServiceCredential {
+  // Operator registration name used to correlate the credential with the
+  // stable service registration delivered by GetSandboxConfig.
+  string service_name = 1;
+  // Gateway-minted JWT with an audience derived from the registration.
+  string token = 2 [(openshell.options.v1.secret) = true];
+  // Absolute expiry of the token, milliseconds since the epoch.
+  int64 expires_at_ms = 3;
 }

--- a/crates/right-openshell/proto/openshell/sandbox.proto
+++ b/crates/right-openshell/proto/openshell/sandbox.proto
@@ -186,6 +186,13 @@ message NetworkEndpoint {
   // endpointless provider profile. Profiles that already define endpoints
   // continue to use those profile endpoints as their credential boundary.
   NetworkCredentialBinding credential_binding = 24;
+  // Explicitly permits credential-bearing traffic to use paths that OpenShell
+  // cannot inspect or rewrite. Defaults to false. This is a security-sensitive
+  // escape hatch and must be explicitly approved.
+  bool allow_uninspected_credentials = 25;
+  // Internal gateway-derived marker indicating that this endpoint belongs to
+  // an attached credentialed provider. User-authored values are ignored.
+  bool provider_credentialed = 26;
 }
 
 // MCP options are grouped so MCP-specific policy can grow without adding more
@@ -382,6 +389,10 @@ message GetSandboxConfigResponse {
   // are "fail_closed" and "retain_last_valid". Unknown or empty values must
   // be treated as fail_closed by the supervisor.
   string policy_validation_failure_mode = 11;
+  // Whether this gateway can mint authenticated extension credentials.
+  // False also covers older gateways that do not advertise this capability;
+  // supervisors preserve their legacy unauthenticated connection behavior.
+  bool extension_authentication_enabled = 12;
 }
 
 // Connection details for one operator-registered supervisor middleware service.
@@ -391,10 +402,23 @@ message SupervisorMiddlewareService {
   string name = 1;
   // gRPC endpoint reachable from the sandbox supervisor.
   string grpc_endpoint = 2;
-  // Operator-owned body limit applied to every binding exposed by the service.
-  uint64 max_body_bytes = 3;
+  // Operator-owned logical payload limit applied to every binding exposed by
+  // the service. This caps HTTP bodies and complete WebSocket messages.
+  uint64 max_payload_bytes = 3;
   // Default RPC timeout for this service. Empty uses the platform default of
   // 500ms. Values use an integer with an `ms` or `s` suffix and must be
   // between 10ms and 30s.
   string timeout = 4;
+  // PEM-encoded trust roots loaded by the gateway from the operator-configured
+  // tls_ca_cert_path. Empty uses the platform trust store.
+  bytes tls_ca_cert_pem = 5;
+  // Exact JWT audience for this service. The gateway resolves an omitted
+  // operator value to a kind-scoped audience derived from the registration
+  // name before sending sandbox config.
+  string audience = 6;
+  // Operator opt-out from extension authentication for this registration.
+  // When true the service may use a plaintext endpoint and OpenShell attaches
+  // no bearer credential; supervisors must not request one. Intended only for
+  // trusted-network development deployments.
+  bool allow_insecure_transport = 7;
 }


### PR DESCRIPTION
Automated re-vendor of the OpenShell protos to **v0.0.110**.

| static check | result |
|---|---|
| `buf breaking` (PACKAGE) | BREAKING |
| `cargo check -p right-openshell` | ok |

<details><summary>buf breaking output</summary>

```
crates/right-openshell/proto/openshell/sandbox.proto:407:3:Field "3" with name "max_payload_bytes" on message "SupervisorMiddlewareService" changed option "json_name" from "maxBodyBytes" to "maxPayloadBytes".
crates/right-openshell/proto/openshell/sandbox.proto:407:10:Field "3" on message "SupervisorMiddlewareService" changed name from "max_body_bytes" to "max_payload_bytes".
```

</details>

<details><summary>cargo check (tail)</summary>

```
warning: unknown experimental feature 'provenance'
• Validating lock
✓ Validating lock in 8.99ms
• Configuring shell
• Configuring cachix
✓ Configuring cachix in 3.84ms
• Evaluating shell
✓ Evaluating shell in 5.89ms (cached)
✓ Configuring shell in 108ms
• Loading tasks
• Evaluating devenv.config.task.config
✓ Evaluating devenv.config.task.config in 451µs (cached)
✓ Loading tasks in 90.0ms
• Running tasks
• Running devenv:files:cleanup
✓ Running devenv:files:cleanup in 112ms
• Running devenv:files
✓ Running devenv:files in 98.7ms
• Running devenv:git-hooks:install
✓ Running devenv:git-hooks:install in 62.9ms
• Running devenv:enterShell
✓ Running devenv:enterShell in 12.0ms
• Running devenv:enterTest
✓ Running devenv:enterTest in 1.43µs (no command)
✓ Running tasks in 286ms
💡 The dotenv file '.env' was not found.
✨ devenv 2.2.1 is newer than devenv input (2.1.2) in devenv.lock. Run 'devenv update' to sync.
   Compiling right-openshell v0.4.2 (/home/runner/work/right-agent/right-agent/crates/right-openshell)
    Checking right-db v0.4.2 (/home/runner/work/right-agent/right-agent/crates/right-db)
    Checking right-process v0.4.2 (/home/runner/work/right-agent/right-agent/crates/right-process)
    Checking right-config v0.4.2 (/home/runner/work/right-agent/right-agent/crates/right-config)
    Checking right-runtime-state v0.4.2 (/home/runner/work/right-agent/right-agent/crates/right-runtime-state)
    Checking right-agent-config v0.4.2 (/home/runner/work/right-agent/right-agent/crates/right-agent-config)
    Checking right-platform-knobs v0.4.2 (/home/runner/work/right-agent/right-agent/crates/right-platform-knobs)
    Checking right-mcp v0.4.2 (/home/runner/work/right-agent/right-agent/crates/right-mcp)
    Checking right-codegen v0.4.2 (/home/runner/work/right-agent/right-agent/crates/right-codegen)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 11.13s
```

</details>

---
A **BREAKING** or **FAILED** result means upstream changed the wire/API shape.
Audit `SandboxReadiness` and any code decoding moved/removed fields, then bump
`MIN_OPENSHELL_VERSION` and the CI `OPENSHELL_VERSION` pin as needed.
This bot surfaces drift only — it does not fix Rust. Full CI runs on this PR only
when `BOT_PR_TOKEN` (a fine-grained PAT) is configured as a repo secret;
otherwise bot-authored PRs don't trigger downstream workflows. Either way, the
`openshell-proto-compat` workflow run itself goes RED when `cargo check` fails,
so a failing proto bump is visible in the Actions tab even without full CI.