### PR TITLE
fix(codegen): preserve single database owner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5957,6 +5957,7 @@ dependencies = [
  "serde-saphyr",
  "serde_json",
  "sha2 0.11.0",
+ "syn 3.0.3",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/right-codegen/Cargo.toml
+++ b/crates/right-codegen/Cargo.toml
@@ -11,7 +11,6 @@ miette = { workspace = true }
 minijinja = { workspace = true }
 right-config = { path = "../right-config", version = "*" }
 right-agent-config = { path = "../right-agent-config", version = "*" }
-right-db = { path = "../right-db", version = "*" }
 right-mcp = { path = "../right-mcp", version = "*" }
 right-platform-knobs = { path = "../right-platform-knobs", version = "*" }
 right-runtime-state = { path = "../right-runtime-state", version = "*" }
@@ -25,5 +24,7 @@ which = { workspace = true }
 
 [dev-dependencies]
 sha2 = { workspace = true }
+right-db = { path = "../right-db", version = "*" }
 tempfile = { workspace = true }
 tokio = { workspace = true }
+syn = { version = "3.0", features = ["full", "visit"] }

--- a/crates/right-codegen/src/pipeline.rs
+++ b/crates/right-codegen/src/pipeline.rs
@@ -45,11 +45,12 @@ fn ensure_agent_secret(
     Ok(new_secret)
 }
 
-/// Run codegen for a single agent.
+/// Run pure file generation for a single agent.
 ///
-/// Generates all per-agent artifacts: settings, agent definitions, schemas,
-/// .claude.json, mcp.json, TOOLS.md, skills, data.db.
-/// Called by the bot at startup. Also used by `right init` and `right agent init`.
+/// Generates per-agent settings, definitions, schemas, MCP configuration, and
+/// skills. Database creation and migrations belong to guarded offline
+/// initialization/restore paths or Aggregator owner startup. Bot startup may
+/// call this only after the Aggregator owner is ready.
 ///
 /// Returns the agent secret (existing or newly generated).
 pub async fn run_single_agent_codegen(
@@ -148,12 +149,6 @@ pub async fn run_single_agent_codegen(
 
     // Write settings.local.json only if absent (CC may write runtime state here).
     write_agent_owned(&claude_dir.join("settings.local.json"), "{}")?;
-
-    // Initialize per-agent memory database.
-    right_db::open_db(&agent.path, false).await.map_err(|e| {
-        miette::miette!("failed to open memory database for '{}': {e:#}", agent.name)
-    })?;
-    tracing::debug!(agent = %agent.name, "data.db initialized");
 
     // Ensure agent has a persistent secret for token derivation.
     let existing_secret = agent.config.as_ref().and_then(|c| c.secret.as_deref());
@@ -462,6 +457,126 @@ pub(crate) mod tests {
             !agent_dir.join("policy.yaml").exists(),
             "OpenShell policy files are retired; codegen must not write one"
         );
+    }
+
+    const OWNER_AGENT_DIR_ENV: &str = "RIGHT_CODEGEN_TEST_OWNER_AGENT_DIR";
+    const OWNER_READY_ENV: &str = "RIGHT_CODEGEN_TEST_OWNER_READY";
+    const OWNER_RELEASE_ENV: &str = "RIGHT_CODEGEN_TEST_OWNER_RELEASE";
+    const OWNER_USABLE_ENV: &str = "RIGHT_CODEGEN_TEST_OWNER_USABLE";
+    const OWNER_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+    const OWNER_WAIT_DELAY: std::time::Duration = std::time::Duration::from_millis(10);
+
+    struct ChildGuard(Option<std::process::Child>);
+
+    impl ChildGuard {
+        fn spawn(command: &mut std::process::Command) -> Self {
+            Self(Some(command.spawn().unwrap()))
+        }
+
+        fn try_wait(&mut self) -> Option<std::process::ExitStatus> {
+            self.0.as_mut().unwrap().try_wait().unwrap()
+        }
+
+        fn wait(mut self) -> std::process::ExitStatus {
+            self.0.take().unwrap().wait().unwrap()
+        }
+    }
+
+    impl Drop for ChildGuard {
+        fn drop(&mut self) {
+            let Some(child) = self.0.as_mut() else {
+                return;
+            };
+            if child.try_wait().unwrap().is_none() {
+                child.kill().unwrap();
+                child.wait().unwrap();
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn database_owner_child() {
+        let Some(agent_dir) = std::env::var_os(OWNER_AGENT_DIR_ENV) else {
+            return;
+        };
+        let ready = std::path::PathBuf::from(std::env::var_os(OWNER_READY_ENV).unwrap());
+        let release = std::path::PathBuf::from(std::env::var_os(OWNER_RELEASE_ENV).unwrap());
+        let usable = std::path::PathBuf::from(std::env::var_os(OWNER_USABLE_ENV).unwrap());
+
+        let owner = right_db::open_connection(Path::new(&agent_dir), true)
+            .await
+            .unwrap();
+        std::fs::write(&ready, []).unwrap();
+        let deadline = tokio::time::Instant::now() + OWNER_WAIT_TIMEOUT;
+        while !release.exists() {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting to release database owner"
+            );
+            tokio::time::sleep(OWNER_WAIT_DELAY).await;
+        }
+
+        let value: i64 = owner
+            .query_one("SELECT 1", [], |row| row.get(0))
+            .await
+            .unwrap();
+        assert_eq!(value, 1);
+        std::fs::write(usable, []).unwrap();
+    }
+
+    #[tokio::test]
+    async fn run_single_agent_codegen_succeeds_with_live_database_owner() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let home = dir.path();
+        let agent_dir = home.join("agents").join("test");
+        std::fs::create_dir_all(agent_dir.join(".claude")).unwrap();
+        std::fs::write(agent_dir.join("IDENTITY.md"), "# Test").unwrap();
+        std::fs::write(
+            agent_dir.join("agent.yaml"),
+            "restart: never\nnetwork_policy: permissive\n",
+        )
+        .unwrap();
+
+        let ready = home.join("owner-ready");
+        let release = home.join("owner-release");
+        let usable = home.join("owner-usable");
+        let mut command = std::process::Command::new(std::env::current_exe().unwrap());
+        command
+            .arg("pipeline::tests::database_owner_child")
+            .arg("--exact")
+            .arg("--nocapture")
+            .env(OWNER_AGENT_DIR_ENV, &agent_dir)
+            .env(OWNER_READY_ENV, &ready)
+            .env(OWNER_RELEASE_ENV, &release)
+            .env(OWNER_USABLE_ENV, &usable);
+        let mut owner = ChildGuard::spawn(&mut command);
+        let deadline = tokio::time::Instant::now() + OWNER_WAIT_TIMEOUT;
+        while !ready.exists() {
+            assert!(
+                owner.try_wait().is_none(),
+                "database owner child exited before publishing readiness"
+            );
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for database owner"
+            );
+            tokio::time::sleep(OWNER_WAIT_DELAY).await;
+        }
+
+        let agent = agent_fixture(&agent_dir);
+        let self_exe = std::path::PathBuf::from("/usr/bin/right");
+        let codegen_result = run_single_agent_codegen(home, &agent, &self_exe, false).await;
+
+        std::fs::write(&release, []).unwrap();
+        let owner_status = owner.wait();
+        assert!(owner_status.success(), "database owner child failed");
+        assert!(
+            usable.exists(),
+            "the retained database owner became unusable"
+        );
+        codegen_result.unwrap();
+        assert!(agent_dir.join(".claude/settings.json").exists());
+        assert!(agent_dir.join("mcp.json").exists());
     }
 
     // The `run_single_agent_codegen_*_policy` and `*_custom_policy_file_path`

--- a/crates/right-codegen/tests/source_policy.rs
+++ b/crates/right-codegen/tests/source_policy.rs
@@ -1,0 +1,235 @@
+//! AST-level guard keeping production codegen free of database openers.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use syn::visit::Visit;
+use syn::{ExprPath, ItemUse, UseTree};
+
+fn source_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+fn rust_files(root: &Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(root).expect("read right-codegen source directory") {
+        let entry = entry.expect("read right-codegen source entry");
+        let path = entry.path();
+        if path.is_dir() {
+            rust_files(&path, out);
+        } else if path.extension().is_some_and(|extension| extension == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+fn is_test_only(attributes: &[syn::Attribute]) -> bool {
+    attributes.iter().any(|attribute| {
+        let syn::Meta::List(list) = &attribute.meta else {
+            return false;
+        };
+        list.path.is_ident("cfg") && list.tokens.to_string().replace(' ', "") == "test"
+    })
+}
+
+#[derive(Default)]
+struct Aliases {
+    targets: HashMap<String, Vec<Vec<String>>>,
+}
+
+impl Aliases {
+    fn insert(&mut self, alias: String, target: Vec<String>) {
+        self.targets.entry(alias).or_default().push(target);
+    }
+
+    fn resolved_paths(&self, path: &syn::Path) -> Vec<Vec<String>> {
+        let initial: Vec<String> = path
+            .segments
+            .iter()
+            .map(|segment| segment.ident.to_string())
+            .collect();
+        let mut resolved = Vec::new();
+        let mut pending = vec![initial];
+        let mut visited = std::collections::HashSet::new();
+
+        while let Some(segments) = pending.pop() {
+            if segments.is_empty() || !visited.insert(segments.clone()) {
+                continue;
+            }
+            if let Some(targets) = self.targets.get(&segments[0]) {
+                for target in targets {
+                    let mut expanded = target.clone();
+                    expanded.extend_from_slice(&segments[1..]);
+                    pending.push(expanded);
+                }
+            }
+            resolved.push(segments);
+        }
+        resolved
+    }
+}
+
+fn collect_use_tree(tree: &UseTree, prefix: &mut Vec<String>, aliases: &mut Aliases) {
+    match tree {
+        UseTree::Path(path) => {
+            prefix.push(path.ident.to_string());
+            collect_use_tree(&path.tree, prefix, aliases);
+            prefix.pop();
+        }
+        UseTree::Name(name) => {
+            let mut target = prefix.clone();
+            target.push(name.ident.to_string());
+            aliases.insert(name.ident.to_string(), target);
+        }
+        UseTree::Rename(rename) => {
+            let mut target = prefix.clone();
+            target.push(rename.ident.to_string());
+            aliases.insert(rename.rename.to_string(), target);
+        }
+        UseTree::Group(group) => {
+            for item in &group.items {
+                collect_use_tree(item, prefix, aliases);
+            }
+        }
+        UseTree::Glob(_) => {}
+    }
+}
+
+#[derive(Default)]
+struct AliasCollector {
+    aliases: Aliases,
+}
+
+impl<'ast> Visit<'ast> for AliasCollector {
+    fn visit_item_mod(&mut self, item: &'ast syn::ItemMod) {
+        if !is_test_only(&item.attrs) {
+            syn::visit::visit_item_mod(self, item);
+        }
+    }
+
+    fn visit_item_fn(&mut self, item: &'ast syn::ItemFn) {
+        if !is_test_only(&item.attrs) {
+            syn::visit::visit_item_fn(self, item);
+        }
+    }
+
+    fn visit_impl_item_fn(&mut self, item: &'ast syn::ImplItemFn) {
+        if !is_test_only(&item.attrs) {
+            syn::visit::visit_impl_item_fn(self, item);
+        }
+    }
+
+    fn visit_item_use(&mut self, item: &'ast ItemUse) {
+        collect_use_tree(&item.tree, &mut Vec::new(), &mut self.aliases);
+    }
+}
+
+fn is_forbidden_path(path: &[String]) -> bool {
+    let Some(last) = path.last() else {
+        return false;
+    };
+    let right_db_opener = path.iter().any(|segment| segment == "right_db")
+        && (last == "open_db"
+            || last.starts_with("open_connection")
+            || last.starts_with("open_database_path"));
+    let provider_store_opener = last == "open"
+        && path
+            .iter()
+            .rev()
+            .nth(1)
+            .is_some_and(|owner| owner == "ProviderStore");
+    right_db_opener || provider_store_opener
+}
+
+struct ForbiddenPathFinder<'a> {
+    aliases: &'a Aliases,
+    paths: Vec<String>,
+}
+
+impl<'ast> Visit<'ast> for ForbiddenPathFinder<'_> {
+    fn visit_item_mod(&mut self, item: &'ast syn::ItemMod) {
+        if !is_test_only(&item.attrs) {
+            syn::visit::visit_item_mod(self, item);
+        }
+    }
+
+    fn visit_item_fn(&mut self, item: &'ast syn::ItemFn) {
+        if !is_test_only(&item.attrs) {
+            syn::visit::visit_item_fn(self, item);
+        }
+    }
+
+    fn visit_impl_item_fn(&mut self, item: &'ast syn::ImplItemFn) {
+        if !is_test_only(&item.attrs) {
+            syn::visit::visit_impl_item_fn(self, item);
+        }
+    }
+
+    fn visit_expr_path(&mut self, expression: &'ast ExprPath) {
+        for path in self.aliases.resolved_paths(&expression.path) {
+            if is_forbidden_path(&path) {
+                self.paths.push(path.join("::"));
+            }
+        }
+        syn::visit::visit_expr_path(self, expression);
+    }
+}
+
+#[test]
+fn production_codegen_has_no_database_openers() {
+    let mut files = Vec::new();
+    rust_files(&source_root(), &mut files);
+    let mut violations = Vec::new();
+
+    for path in files {
+        let source = std::fs::read_to_string(&path).expect("read right-codegen source file");
+        let syntax = syn::parse_file(&source).expect("parse right-codegen source file");
+        let mut collector = AliasCollector::default();
+        collector.visit_file(&syntax);
+        let mut finder = ForbiddenPathFinder {
+            aliases: &collector.aliases,
+            paths: Vec::new(),
+        };
+        finder.visit_file(&syntax);
+        for forbidden in finder.paths {
+            violations.push(format!("{}: {forbidden}", path.display()));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "right-codegen only generates files; database creation and migration belong to guarded offline CLI paths or the Aggregator owner:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn policy_resolves_import_aliases() {
+    let syntax = syn::parse_file(
+        r#"
+        use right_db as database;
+        use database::open_connection as open;
+        use right_providers::ProviderStore as Store;
+        use Store as AliasedStore;
+        fn forbidden() {
+            open(".", true);
+            AliasedStore::open(".");
+        }
+        "#,
+    )
+    .unwrap();
+    let mut collector = AliasCollector::default();
+    collector.visit_file(&syntax);
+    let mut finder = ForbiddenPathFinder {
+        aliases: &collector.aliases,
+        paths: Vec::new(),
+    };
+    finder.visit_file(&syntax);
+
+    assert_eq!(
+        finder.paths,
+        [
+            "right_db::open_connection",
+            "right_providers::ProviderStore::open"
+        ]
+    );
+}


### PR DESCRIPTION
## Root cause
After #211, the Aggregator correctly retains the sole standard-local `data.db` connection. Bot startup waits for owner readiness, then `run_single_agent_codegen` opened the same database again. Turso rejected that second process with `File is locked by another process`, so all bots exited while the Aggregator stayed healthy.

## Fix
- make per-agent codegen pure file generation; remove its database open
- retain DB creation/migration in guarded CLI init/restore and Aggregator owner startup
- add a real cross-process regression with a live retained owner connection
- add AST source policy forbidding DB/provider-store openers in production codegen

## Verification
- red regression reproduced the production lock error before the fix
- `cargo nextest run -p right-codegen` — 160 passed
- source policy — 2 passed
- `cargo check -p right-bot -p right-codegen -p right` — passed
- Clippy and format — passed

Production feedback loop: `right status` currently shows Aggregator healthy and all three bots failed; process-compose stderr points exactly at the removed codegen open.