### PR TITLE
docs: update site and sandbox references

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -526,14 +526,8 @@ defect.
 2. Use the matching helper. No bare `std::fs::write`.
 3. Run `cargo test registry_covers_all_per_agent_writes` to verify the
    registry is complete.
-4. If `Regenerated(SandboxRecreate)` — exercise the migration path
-   manually.
-5. If the new output is policy-related, apply via
-   `write_and_apply_sandbox_policy` only. Adding a new network endpoint
-   is fine; adding a new filesystem rule requires `SandboxRecreate`
-   treatment.
-6. Never require `right agent init` for existing agents to adopt the
-   change. They upgrade via `right restart <agent>`.
+4. Never require `right agent init` for existing agents to adopt the change.
+   They upgrade via `right restart <agent>`.
 
 See: `docs/architecture/upgrades.md` for the upgrade-flow walkthrough,
 identity-mirror semantics, and non-goals.
@@ -542,9 +536,6 @@ identity-mirror semantics, and non-goals.
 
 - `AGENTS.md` → `Upgrade-friendly design`, `Never delete sandboxes for
   recovery`, `Self-healing platform` — conventions this model implements.
-- `docs/architecture/lifecycle.md` → `Sandbox migration (filesystem
-  policy change)` — the migration flow used by
-  `Regenerated(SandboxRecreate)`.
 
 ## Integration Tests Using Live Sandboxes
 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ you manage everything from Telegram: `/mcp` and `/providers` open the dashboard.
 ## docs
 
 full story, install guide, security model, concepts, and commands:
-**https://onsails.github.io/right-agent/**
+**https://right-agent.ai/**
 
-- [Install](https://onsails.github.io/right-agent/docs/install/)
-- [Concepts](https://onsails.github.io/right-agent/docs/concepts/)
-- [Security model](https://onsails.github.io/right-agent/docs/security/)
-- [Telegram commands](https://onsails.github.io/right-agent/docs/commands/)
+- [Install](https://right-agent.ai/docs/install/)
+- [Concepts](https://right-agent.ai/docs/concepts/)
+- [Security model](https://right-agent.ai/docs/security/)
+- [Telegram commands](https://right-agent.ai/docs/commands/)
 
 Contributor docs stay in the repo: [ARCHITECTURE.md](ARCHITECTURE.md),
 [PROMPT_SYSTEM.md](PROMPT_SYSTEM.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
 # Security
 
 The security model lives on the site:
-https://onsails.github.io/right-agent/docs/security/
+https://right-agent.ai/docs/security/

--- a/docs/architecture/layout.md
+++ b/docs/architecture/layout.md
@@ -24,8 +24,10 @@
 - `run/process-compose.yaml`, `run/state.json` (carries `pc_port` +
   `pc_api_token`), and `run/internal.sock` (mode 0600 typed bot↔Aggregator DB
   and control-plane IPC).
-- `backups/<agent>/<YYYYMMDD-HHMM>/` — `sandbox.tar.gz` plus `backup.json`
-  and optional `agent.yaml`, `allowlist.yaml`, and `data.db` for full backups.
+- `backups/<agent>/<YYYYMMDD-HHMM>/` — full `right agent backup` output:
+  `sandbox.tar.gz`, `backup.json`, and optional `agent.yaml`, `allowlist.yaml`,
+  and `data.db`. Pre-destroy backups omit `backup.json` and may also preserve a
+  legacy `policy.yaml` when an upgraded agent still has that retired file.
   `right agent backup` excludes rebuildable sandbox dirs by default (`.cache`,
   `.venv`, `.npm`, `.uv`); `--include-rebuildable` opts into forensic sandbox
   archives. Normal agent backups contain only the top-level `data.db` snapshot,

--- a/docs/architecture/layout.md
+++ b/docs/architecture/layout.md
@@ -10,7 +10,7 @@
 
 - `config.yaml` — global config (tunnel).
 - `agents/<name>/` — per-agent state. Key files: `agent.yaml`,
-  `allowlist.yaml`, `policy.yaml`, and `data.db`. During runtime the Aggregator
+  `allowlist.yaml`, and `data.db`. During runtime the Aggregator
   owns the sole standard-local writable connection; `data.db-wal` and
   `data.db-shm` may exist, but legacy `data.db-tshm` must not be created.
   `.claude/.credentials.json` is a host-only symlink to
@@ -22,15 +22,14 @@
   output, only present when `/debug` is on).
 - `providers.db` — provider authority and encrypted-at-rest-by-host-permissions credential store; the Aggregator owns its only live connection.
 - `run/process-compose.yaml`, `run/state.json` (carries `pc_port` +
-  `pc_api_token`), `run/internal.sock` (mode 0600 typed bot↔Aggregator DB and
-  control-plane IPC), and `run/ssh/<agent>.ssh-config`.
-- `backups/<agent>/<YYYYMMDD-HHMM>/` — `sandbox.tar.gz` plus optional
-  `agent.yaml` + `allowlist.yaml` + `data.db` + `policy.yaml` for full
-  backups. `right agent backup` excludes rebuildable sandbox dirs by
-  default (`.cache`, `.venv`, `.npm`, `.uv`); `--include-rebuildable` opts
-  into forensic sandbox archives. No-sandbox archives, including destroy
-  safety backups, exclude `data.db` and every `data.db-*` sidecar; the only
-  durable database backup file is the top-level `data.db` snapshot.
+  `pc_api_token`), and `run/internal.sock` (mode 0600 typed bot↔Aggregator DB
+  and control-plane IPC).
+- `backups/<agent>/<YYYYMMDD-HHMM>/` — `sandbox.tar.gz` plus `backup.json`
+  and optional `agent.yaml`, `allowlist.yaml`, and `data.db` for full backups.
+  `right agent backup` excludes rebuildable sandbox dirs by default (`.cache`,
+  `.venv`, `.npm`, `.uv`); `--include-rebuildable` opts into forensic sandbox
+  archives. Database sidecars are never backup artifacts; the only durable
+  database backup file is the top-level `data.db` snapshot.
 - `logs/<agent>.log.<date>` — per-agent daily log rotation.
   `mcp-aggregator.log` for the shared aggregator.
 - `cache/whisper/ggml-<model>.bin` — STT models (downloaded at `right up`).

--- a/docs/architecture/layout.md
+++ b/docs/architecture/layout.md
@@ -28,8 +28,8 @@
   and optional `agent.yaml`, `allowlist.yaml`, and `data.db` for full backups.
   `right agent backup` excludes rebuildable sandbox dirs by default (`.cache`,
   `.venv`, `.npm`, `.uv`); `--include-rebuildable` opts into forensic sandbox
-  archives. Database sidecars are never backup artifacts; the only durable
-  database backup file is the top-level `data.db` snapshot.
+  archives. Normal agent backups contain only the top-level `data.db` snapshot,
+  never its sidecars; database-repair forensic backups preserve a different set.
 - `logs/<agent>.log.<date>` — per-agent daily log rotation.
   `mcp-aggregator.log` for the shared aggregator.
 - `cache/whisper/ggml-<model>.bin` — STT models (downloaded at `right up`).

--- a/docs/architecture/learning.md
+++ b/docs/architecture/learning.md
@@ -28,13 +28,12 @@ Replaces the prior fork-probe classifier.
    are computed on demand by `right_agent::usage::turn_baseline::compute`.
 
    The skill index is built by `learning_prefilter::collect_rightx_skill_index`.
-   For sandboxed agents it reads `/sandbox/.claude/skills/rightx-*/SKILL.md`
-   from inside the agent's sandbox via gRPC `exec_in_sandbox` (a `sh -c`
-   frontmatter dump, parsed into name + excerpt). For `sandbox: mode: none`
-   agents it reads the host filesystem. Each mode has exactly one source —
-   there is no fallback path. A sandbox read error returns
-   `PrefilterDecision::Skip` rather than an empty index; an empty index would
-   allow the classifier to recommend creating a skill that already exists.
+   It reads `/sandbox/.claude/skills/rightx-*/SKILL.md` from the agent's
+   microsandbox through the SDK exec stream, then parses each skill's name and
+   excerpt. This guest path is the only source; there is no host fallback. A
+   sandbox read error returns `PrefilterDecision::Skip` rather than an empty
+   index, because an empty index could let the classifier recommend creating a
+   skill that already exists.
 
 3. **Probe-writer** (`bot::learning_probe_writer`): when the prefilter
    returns non-Skip, the worker forks the main CC session with the decision

--- a/docs/architecture/lifecycle.md
+++ b/docs/architecture/lifecycle.md
@@ -262,7 +262,7 @@ right agent init <name> --from-backup <path>
   ├─ Restore config/control-plane files to the new agent dir
   ├─ Remove copied data.db-* sidecars before opening the DB; discard
   │   tar-extracted data.db and use only backup/data.db as canonical
-  ├─ Normalize agent.yaml and regenerate BOOTSTRAP.md
+  ├─ Normalize and validate agent.yaml
   ├─ Create a timestamped microsandbox through the shared bot sandbox spec,
   │   upload and extract the archive, and reconcile the identity mirror
   ├─ On any later failure, delete the created microsandbox before removing the

--- a/docs/architecture/lifecycle.md
+++ b/docs/architecture/lifecycle.md
@@ -117,7 +117,7 @@ right bot --agent <name>  (spawned by process-compose)
   ├─ Per-agent codegen:
   │   ├─ settings.json, schemas
   │   ├─ .claude.json, credentials symlink, mcp.json
-  │   ├─ TOOLS.md, skills install, policy.yaml
+  │   ├─ TOOLS.md and bundled skills
   │   └─ filesystem/codegen state only; live database work uses typed IPC
   ├─ Microsandbox lifecycle (`right-sandbox`):
   │   ├─ ensure_runtime_installed + diagnose_host (hypervisor preflight)
@@ -262,7 +262,7 @@ right agent init <name> --from-backup <path>
   ├─ Restore config/control-plane files to the new agent dir
   ├─ Remove copied data.db-* sidecars before opening the DB; discard
   │   tar-extracted data.db and use only backup/data.db as canonical
-  ├─ Normalize agent.yaml and regenerate bootstrap policy
+  ├─ Normalize agent.yaml and regenerate BOOTSTRAP.md
   ├─ Create a timestamped microsandbox through the shared bot sandbox spec,
   │   upload and extract the archive, and reconcile the identity mirror
   ├─ On any later failure, delete the created microsandbox before removing the

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -395,10 +395,10 @@ registration, so it resets when the turn unregisters.
 Scope-from-target invariant: the destination `(chat_id, effective_thread_id)`
 is read server-side from the registered `ProgressTarget`, never from agent
 arguments — identical to the `send_progress` scope rule. The agent cannot
-address another chat or topic. To support downloading attachments out of the
-sandbox before delivery, `ProgressTarget` now also carries `agent_dir`,
-`ssh_config_path`, and `resolved_sandbox`; for `sandbox: mode: none` agents the
-`/sandbox/outbox/` paths resolve directly on the host instead.
+address another chat or topic. For attachment delivery, `ProgressTarget` also
+carries `agent_dir` and the invocation's live sandbox handle. Files under
+`/sandbox/outbox/` are copied to host staging through the SDK before delivery;
+a missing sandbox handle fails closed instead of falling back to host paths.
 
 ## Telegram channel tools
 

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -396,9 +396,9 @@ Scope-from-target invariant: the destination `(chat_id, effective_thread_id)`
 is read server-side from the registered `ProgressTarget`, never from agent
 arguments — identical to the `send_progress` scope rule. The agent cannot
 address another chat or topic. For attachment delivery, `ProgressTarget` also
-carries `agent_dir` and the invocation's live sandbox handle. Files under
-`/sandbox/outbox/` are copied to host staging through the SDK before delivery;
-a missing sandbox handle fails closed instead of falling back to host paths.
+carries `agent_dir` and the sandbox handle captured when the invocation was
+registered. Files under `/sandbox/outbox/` are copied to host staging through
+the SDK before delivery; a missing handle fails closed without a host fallback.
 
 ## Telegram channel tools
 


### PR DESCRIPTION
## Summary
- point public documentation links at right-agent.ai
- remove retired OpenShell policy, SSH, and sandboxless references from active architecture docs
- align learning and attachment documentation with microsandbox SDK handles

## Verification
- `git diff --check`
- active documentation search for retired policy, SSH, and sandboxless guidance