### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## [0.5.1] - 2026-09-01
+
+
+### Features
+
+- **rich-content**: Agent-authored messages use validated RichContent blocks
+- **telegram**: Support channel post attachments
+
 ## [0.5.0] - 2026-08-28
 
 ### Sandbox & Providers

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5736,7 +5736,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "right"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -5794,7 +5794,7 @@ dependencies = [
 
 [[package]]
 name = "right-agent"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "right-agent-config"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "miette",
  "serde",
@@ -5845,7 +5845,7 @@ dependencies = [
 
 [[package]]
 name = "right-bot"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -5912,7 +5912,7 @@ dependencies = [
 
 [[package]]
 name = "right-codegen"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "dirs",
  "include_dir",
@@ -5939,7 +5939,7 @@ dependencies = [
 
 [[package]]
 name = "right-config"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "dirs",
  "miette",
@@ -5952,7 +5952,7 @@ dependencies = [
 
 [[package]]
 name = "right-dashboard"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -5976,7 +5976,7 @@ dependencies = [
 
 [[package]]
 name = "right-db"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "fs4 1.1.0",
@@ -5992,7 +5992,7 @@ dependencies = [
 
 [[package]]
 name = "right-hostpath"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "tempfile",
  "thiserror",
@@ -6000,7 +6000,7 @@ dependencies = [
 
 [[package]]
 name = "right-lifecycle"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "right-db",
@@ -6013,7 +6013,7 @@ dependencies = [
 
 [[package]]
 name = "right-mcp"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -6050,7 +6050,7 @@ dependencies = [
 
 [[package]]
 name = "right-memory"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "fastrand",
@@ -6068,11 +6068,11 @@ dependencies = [
 
 [[package]]
 name = "right-platform-knobs"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "right-platform-store"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "futures",
  "miette",
@@ -6085,7 +6085,7 @@ dependencies = [
 
 [[package]]
 name = "right-process"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "nix 0.31.3",
  "tempfile",
@@ -6095,14 +6095,14 @@ dependencies = [
 
 [[package]]
 name = "right-prompt-safety"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ironclaw_safety",
 ]
 
 [[package]]
 name = "right-providers"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "fs4 1.1.0",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "right-rich-content"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "schemars",
  "serde",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "right-runtime-state"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64 0.22.1",
  "miette",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "right-sandbox"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "microsandbox",
@@ -6165,7 +6165,7 @@ dependencies = [
 
 [[package]]
 name = "right-stt"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "futures",
  "reqwest",
@@ -6179,7 +6179,7 @@ dependencies = [
 
 [[package]]
 name = "right-ui"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "inquire",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION



## 🤖 New release

* `right-sandbox`: 0.5.0 -> 0.5.1
* `right-agent`: 0.5.0 -> 0.5.1
* `right-bot`: 0.5.0 -> 0.5.1
* `right`: 0.5.0 -> 0.5.1
* `right-rich-content`: 0.5.0 -> 0.5.1
* `right-agent-config`: 0.5.0 -> 0.5.1
* `right-config`: 0.5.0 -> 0.5.1
* `right-db`: 0.5.0 -> 0.5.1
* `right-lifecycle`: 0.5.0 -> 0.5.1
* `right-dashboard`: 0.5.0 -> 0.5.1
* `right-mcp`: 0.5.0 -> 0.5.1
* `right-platform-knobs`: 0.5.0 -> 0.5.1
* `right-runtime-state`: 0.5.0 -> 0.5.1
* `right-codegen`: 0.5.0 -> 0.5.1
* `right-prompt-safety`: 0.5.0 -> 0.5.1
* `right-memory`: 0.5.0 -> 0.5.1
* `right-providers`: 0.5.0 -> 0.5.1
* `right-stt`: 0.5.0 -> 0.5.1
* `right-ui`: 0.5.0 -> 0.5.1
* `right-platform-store`: 0.5.0 -> 0.5.1
* `right-process`: 0.5.0 -> 0.5.1
* `right-hostpath`: 0.5.0 -> 0.5.1

<details><summary><i><b>Changelog</b></i></summary><p>




## `right`

<blockquote>

## [0.5.1] - 2026-09-01

### Features

- **rich-content**: Agent-authored messages use validated RichContent blocks
- **telegram**: Support channel post attachments
</blockquote>




















</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).